### PR TITLE
Install django_nose all the time, so installs work better.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,7 @@ lazy
 fs
 pypng
 -e git+https://github.com/pmitros/django-pyfs.git@514607d78535fd80bfd23184cd292ee5799b500d#egg=djpyfs
+
+# Strictly speaking, this is only for testing, but is in the INSTALLED_APPS,
+# and it's easier just to install it.
+django_nose

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 coverage
 diff-cover >= 0.2.1
-django_nose
 mock
 pylint==0.28
 pep8


### PR DESCRIPTION
Without this, a new clone won't run with "requirements.txt", it would need "test-requirements.txt".