### PR TITLE
Allow additional services in workbench settings.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,4 @@ mock
 pylint==0.28
 pep8
 rednose
-bok_choy==0.3.2
+bok_choy==0.3.3

--- a/workbench/settings.py
+++ b/workbench/settings.py
@@ -194,5 +194,9 @@ LOGGING = {
 WORKBENCH = {
     'reset_state_on_restart': (
         os.environ.get('WORKBENCH_RESET_STATE_ON_RESTART', "false").lower() == "true"
-    )
+    ),
+
+    'services': {
+        'fs': 'xblock.reference.plugins.FSService'
+    }
 }

--- a/workbench/test/test_problems.py
+++ b/workbench/test/test_problems.py
@@ -1,5 +1,6 @@
 """Test that problems and problem submission works well."""
 import time
+import unittest
 
 from selenium.common.exceptions import StaleElementReferenceException
 
@@ -36,6 +37,7 @@ class ProblemInteractionTest(SeleniumTest):
         )
         self.addCleanup(scenarios.remove_scenario, "test_many_problems")
 
+    @unittest.skip("Flaky test: PLAT-614")
     def test_many_problems(self):
         # Test that problems work properly.
         self.browser.get(self.live_server_url + "/scenario/test_many_problems")
@@ -45,6 +47,7 @@ class ProblemInteractionTest(SeleniumTest):
         # Find the numbers on the page.
         nums = self.browser.find_elements_by_css_selector("p.the_numbers")
         num_pairs = [tuple(int(n) for n in num.text.split()) for num in nums]
+
         # They should be all different.
         self.assertEqual(len(set(num_pairs)), self.num_problems)
 


### PR DESCRIPTION
I'd like to be able to install a stub "verification service" for local testing in XBlock workbench.  This will make it much easier to simulate different states of the system, without needing to install the XBlock in the LMS.

@jimabramson please review.