### PR TITLE
Make ThumbsAside available, update XBlock release hash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ lazy
 
 # XBlock
 # This is not in/from PyPi, since it moves fast
--e git+https://github.com/edx/XBlock.git@8e496cff186ed33cf92964faab13ccb3691ee211#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@tag-master-2015-05-22#egg=XBlock
 #-e ../XBlock
 
 # Acid xblock

--- a/sample_xblocks/thumbs/__init__.py
+++ b/sample_xblocks/thumbs/__init__.py
@@ -1,1 +1,1 @@
-from .thumbs import ThumbsBlock
+from .thumbs import ThumbsAside, ThumbsBlock


### PR DESCRIPTION
The entry point "thumbs-aside" references sample_xblock.thumbs:ThumbsAside,
which does not exist, so we make it available in the referenced location.

We also update the release hash for XBlock to the latest version.

Both changes are needed to make the Problem Builder tests pass again.