### PR TITLE
Added activate_block_id support for workbench

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,3 +24,4 @@ David Baumgold <david@davidbaumgold.com>
 Piotr Mitros <pmitros@edx.org>
 Steven Burch <stv@stanford.edu>
 Brad Smith <usernamenumber@gmail.com>
+Eugeny Kolpakov <eugeny.kolpakov@gmail.com>

--- a/sample_xblocks/basic/structure.py
+++ b/sample_xblocks/basic/structure.py
@@ -15,7 +15,7 @@ class Sequence(XBlock):
     def student_view(self, context=None):
         """Provide default student view."""
         frag = Fragment()
-        child_frags = self.runtime.render_children(self, context)
+        child_frags = self.runtime.render_children(self, context=context)
         frag.add_frags_resources(child_frags)
 
         frag.add_content(self.runtime.render_template("sequence.html", children=child_frags))
@@ -58,7 +58,7 @@ class SidebarBlock(XBlock):
     def student_view(self, context=None):
         """Provide default student view."""
         result = Fragment()
-        child_frags = self.runtime.render_children(self, context)
+        child_frags = self.runtime.render_children(self, context=context)
         result.add_frags_resources(child_frags)
         result.add_css("""
             .sidebar {

--- a/workbench/views.py
+++ b/workbench/views.py
@@ -64,7 +64,11 @@ def show_scenario(request, scenario_id, view_name='student_view', template='work
     usage_id = scenario.usage_id
     runtime = WorkbenchRuntime(student_id)
     block = runtime.get_block(usage_id)
-    frag = block.render(view_name)
+    render_context = {
+        'activate_block_id': request.GET.get('activate_block_id', None)
+    }
+
+    frag = block.render(view_name, render_context)
     log.info("End show_scenario %s", scenario_id)
     return render_to_response(template, {
         'scenario': scenario,


### PR DESCRIPTION
This PR adds support for `activate_block_id` feature: [upstream PR](https://github.com/edx/edx-platform/pull/8768).