### PR TITLE
Add Vagrant support and provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ var/
 *.pyc
 local_settings.py
 *.egg-info
+*.egg
 .treerc
 .coverage
 htmlcov
@@ -17,3 +18,4 @@ doc/_build
 nosetests.xml
 coverage.xml
 .vagrant
+.*

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ doc/_build
 .pip_cache
 nosetests.xml
 coverage.xml
+.vagrant

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,33 @@
 #!/usr/bin/make -f
 
+# Commands
+APT_GET=apt-get -y
+HOSTNAME=hostname
+INSTALL_PACKAGE=$(APT_GET) install
+# Files
 SQLITE_DB=var/workbench.db
+# Packages
+LIBS_BUILD=build-essential
+LIBS_PYTHON=python python-dev python-distribute python-pip
+LIBS_LIBXML=libxml2-dev libxslt1-dev zlib1g-dev
+LIBS_SOURCE_CONTROL=git
+# Variables
+HOSTNAME_VALUE=workbench
 
 all: install test
+
+.PHONY: provision
+provision:
+	$(HOSTNAME) "$(HOSTNAME_VALUE)"
+	echo "$(HOSTNAME_VALUE)" > /etc/hostname
+	$(APT_GET) update
+	$(APT_GET) upgrade
+	$(INSTALL_PACKAGE) apt-transport-https
+	$(INSTALL_PACKAGE) $(LIBS_SOURCE_CONTROL)
+	$(INSTALL_PACKAGE) $(LIBS_BUILD)
+	$(INSTALL_PACKAGE) $(LIBS_PYTHON)
+	$(INSTALL_PACKAGE) $(LIBS_LIBXML)
+	$(MAKE) install
 
 .PHONY: install
 install: pip $(SQLITE_DB)

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,12 @@ LIBS_PYTHON=python python-dev python-distribute python-pip
 LIBS_LIBXML=libxml2-dev libxslt1-dev zlib1g-dev
 LIBS_SOURCE_CONTROL=git
 # Variables
+HOST_PORT=8008
+HOST_ADDRESS=0
 HOSTNAME_VALUE=workbench
 
-all: install test
+all: install
+	$(MAKE) run
 
 .PHONY: provision
 provision:
@@ -49,7 +52,7 @@ $(SQLITE_DB): var
 	python manage.py syncdb --noinput
 
 .PHONY: test
-test:
+test: install
 	python manage.py test
 
 .PHONY: quality
@@ -61,3 +64,6 @@ quality:
 cover:
 	coverage run manage.py test
 	coverage report
+
+run:
+	python ./manage.py runserver $(HOST_ADDRESS):$(HOST_PORT)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # Commands
 APT_GET=apt-get -y
+CP=cp
 HOSTNAME=hostname
 INSTALL_PACKAGE=$(APT_GET) install
 # Files
@@ -15,6 +16,8 @@ LIBS_SOURCE_CONTROL=git
 HOST_PORT=8008
 HOST_ADDRESS=0
 HOSTNAME_VALUE=workbench
+SUPERVISOR_CONF=supervisor.conf  # Comment-out to disable
+SUPERVISOR_CTL=supervisorctl
 
 all: install
 	$(MAKE) run
@@ -30,6 +33,12 @@ provision:
 	$(INSTALL_PACKAGE) $(LIBS_BUILD)
 	$(INSTALL_PACKAGE) $(LIBS_PYTHON)
 	$(INSTALL_PACKAGE) $(LIBS_LIBXML)
+ifdef SUPERVISOR_CONF
+	$(INSTALL_PACKAGE) supervisor
+	$(CP) $(SUPERVISOR_CONF) /etc/supervisor/conf.d/workbench.conf
+	$(SUPERVISOR_CTL) reread
+	$(SUPERVISOR_CTL) update
+endif
 	$(MAKE) install
 
 .PHONY: install

--- a/README.rst
+++ b/README.rst
@@ -15,25 +15,25 @@ This code runs on Python 2.7.
 
 1.  Get a local copy of this repo.
 
-2.  (Optional)  Create and activate a virtualenv to work in.
+        $ git clone https://github.com/edx/xblock-sdk.git
 
-3.  Install the requirements and register the XBlock entry points with (you may
-    need to sudo this if you don't use virtualenv):
+2. Enter the project directory.
 
-        $ make install
+        $ cd xblock-sdk
 
-4.  Run the Django development server:
+3.  Start the development server.
 
-        $ python manage.py runserver
+        $ vagrant up
 
-5.  Open a web browser to: http://127.0.0.1:8000
+4.  Open a web browser to: http://127.0.0.1:8008
+
 
 Testing
 --------
 
 To install all requirements and run the test suite:
 
-    $ make
+    $ make test
 
 This will run:
 
@@ -112,6 +112,32 @@ We have been moving towards hosting XBlocks in external repositories, some of
 which have been installed and will appear in the workbench:
 
 ACID XBlock: https://github.com/edx/acid-block
+
+
+Advanced Installation
+---------------------
+
+In order to lower the barrier to entry in developing XBlocks, we aim to
+ship with "batteries included" as much as possible, keeping
+configuration and installation steps to a minimum. Hence, the default,
+recommended use case is to run the development server from within a
+preconfigured virtual machine.
+
+However, as this is still a djangoapp, it supports a number of
+use-cases:
+
+1. Run via virtualenv
+
+        $ mkvirtualenv sdk
+        $ workon sdk
+        $ make install  # pip install -r requirements/{base,test}.txt; pip install -e .
+        $ make run  # python manage.py runserver 0:8008
+        $ deactivate
+
+2. Provision "Bare metal" on Debian/Ubuntu
+
+        $ make provision  # may need to be run with `sudo`
+        # Installs both system and Python packages
 
 
 License

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure('2') do |config|
+  config.vm.box = 'ubuntu/precise64'
+  config.vm.synced_folder '.', '/home/vagrant'
+  config.vm.network 'forwarded_port', guest: 8008, host: 8008
+  config.vm.provision 'shell' do |shell|
+    shell.path = 'Makefile'
+    shell.args = [
+      'provision',
+    ]
+  end
+  config.vm.provider 'virtualbox' do |vb|
+    # We need to increase this to install lxml
+    vb.memory = 1024
+  end
+end

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,0 +1,5 @@
+[program:workbench]
+command=make run
+directory=/home/vagrant
+user=vagrant
+autostart=true


### PR DESCRIPTION
Instead of co-opting an existing development environment, it would be ideal to streamline the process to provide a dedicated environment for XBlock development.

At last year's OpenEdX conference, I demonstrated the work we had done to containerize the SDK within Docker [1].

Given edX's existing workflows which use Vagrant, I have ported the work to that ecosystem.

[1] https://github.com/Stanford-Online/docker-xblock-sdk