### PR TITLE
Revert "Document fork with Python 3 support"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,7 @@ This repository consists of three main components to assist in the creation of n
 Installation
 ------------
 
-This code runs on Python 2.7. If you prefer to use Python 3, there is `a fork
-of xblock-sdk that provides Python 3 support`_, but this fork is not yet
-supported by edX.
+This code runs on Python 2.7.
 
 1.  Get a local copy of this repo.
 
@@ -29,8 +27,6 @@ supported by edX.
         $ python manage.py runserver
 
 5.  Open a web browser to: http://127.0.0.1:8000
-
-.. _a fork of xblock-sdk that provides Python 3 support: https://github.com/singingwolfboy/xblock-sdk/tree/py3
 
 Testing
 --------


### PR DESCRIPTION
This reverts commit 25587e6e82b033c51f4f450e065c4f4e3afcd857.

I'm a huge fan of writing py3-compatible code, but I don't think we want
this any longer. This repo isn't actively maintained.

Many of the changes in that fork could presumably be brought over here,
but advertising a fork only serves to confuse.