### PR TITLE
Install acid block only for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,6 @@ lazy
 -e git+https://github.com/edx/XBlock.git@tag-master-2015-05-22#egg=XBlock
 #-e ../XBlock
 
-# Acid xblock
--e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-
 fs
 pypng
 -e git+https://github.com/pmitros/django-pyfs.git@514607d78535fd80bfd23184cd292ee5799b500d#egg=djpyfs

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,6 @@ pylint==0.28
 pep8
 rednose
 bok_choy==0.3.3
+
+# Acid xblock
+-e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock


### PR DESCRIPTION
If installed all the time, then everyone developing XBlocks has to wade 
through the acid asides.