### PR TITLE
Move database and log files to `var` subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-*.log.*
-*.log
-*.db
+var/
 *.pot
 *.pyc
 local_settings.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-SQLITE_DB=workbench.db
+SQLITE_DB=var/workbench.db
 
 all: install test
 
@@ -16,7 +16,10 @@ pip:
 	pip install -e .
 	pip install -r test-requirements.txt
 
-$(SQLITE_DB):
+var:
+	mkdir var || true
+
+$(SQLITE_DB): var
 	# The --noinput flag is for non-interactive runs, e.g. TravisCI.
 	python manage.py syncdb --noinput
 

--- a/workbench/settings.py
+++ b/workbench/settings.py
@@ -26,7 +26,7 @@ else:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': 'workbench.db'
+            'NAME': 'var/workbench.db'
         }
     }
 
@@ -173,7 +173,7 @@ LOGGING = {
         'logfile': {
             'level': 'DEBUG',
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': 'workbench.log',
+            'filename': 'var/workbench.log',
             'maxBytes': 50000,
             'backupCount': 2,
         }


### PR DESCRIPTION
It's easier to keep track of things without littering the root project
directory, as well as being more in line with traditional POSIX file
hierarchy.