### PR TITLE
removed the aside from the thumbs sample_xblock

### DIFF
--- a/sample_xblocks/thumbs/__init__.py
+++ b/sample_xblocks/thumbs/__init__.py
@@ -1,4 +1,4 @@
 """
 Provide XBlock with thumbs-up/thumbs-down voting
 """
-from .thumbs import ThumbsAside, ThumbsBlock
+from .thumbs import ThumbsBlock

--- a/sample_xblocks/thumbs/static/js/src/thumbs.js
+++ b/sample_xblocks/thumbs/static/js/src/thumbs.js
@@ -1,7 +1,3 @@
-function ThumbsAside(runtime, element, block_element, init_args) {
-    return new ThumbsBlock(runtime, element, init_args);
-}
-
 function ThumbsBlock(runtime, element, init_args) {
     function updateVotes(votes) {
         $('.upvote .count', element).text(votes.up);

--- a/sample_xblocks/thumbs/thumbs.py
+++ b/sample_xblocks/thumbs/thumbs.py
@@ -111,11 +111,11 @@ class ThumbsAside(ThumbsBlockBase, XBlockAside):
     This demonstrates multiple data scopes and ajax handlers.
     """
 
-    @XBlockAside.aside_for('student_view')
-    def student_view_aside(self, block, context=None):  # pylint: disable=unused-argument
-        """
-        Allow the thumbs up/down-voting to work as an Aside as well as an XBlock.
-        """
-        fragment = self.student_view(context)
-        fragment.initialize_js('ThumbsAside')
-        return fragment
+    # @XBlockAside.aside_for('student_view')
+    # def student_view_aside(self, block, context=None):  # pylint: disable=unused-argument
+    #     """
+    #     Allow the thumbs up/down-voting to work as an Aside as well as an XBlock.
+    #     """
+    #     fragment = self.student_view(context)
+    #     fragment.initialize_js('ThumbsAside')
+    #     return fragment

--- a/sample_xblocks/thumbs/thumbs.py
+++ b/sample_xblocks/thumbs/thumbs.py
@@ -9,7 +9,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class ThumbsBlockBase(object):
+class ThumbsBlock(XBlock):
     """
     An XBlock with thumbs-up/thumbs-down voting.
 
@@ -87,16 +87,4 @@ class ThumbsBlockBase(object):
                 </vertical_demo>
              """)
         ]
-
-
-class ThumbsBlock(ThumbsBlockBase, XBlock):
-    """
-    An XBlock with thumbs-up/thumbs-down voting.
-
-    Vote totals are stored for all students to see.  Each student is recorded
-    as has-voted or not.
-
-    This demonstrates multiple data scopes and ajax handlers.
-    """
-    pass
 

--- a/sample_xblocks/thumbs/thumbs.py
+++ b/sample_xblocks/thumbs/thumbs.py
@@ -100,22 +100,3 @@ class ThumbsBlock(ThumbsBlockBase, XBlock):
     """
     pass
 
-
-class ThumbsAside(ThumbsBlockBase, XBlockAside):
-    """
-    An XBlockAside with thumbs-up/thumbs-down voting.
-
-    Vote totals are stored for all students to see.  Each student is recorded
-    as has-voted or not.
-
-    This demonstrates multiple data scopes and ajax handlers.
-    """
-
-    # @XBlockAside.aside_for('student_view')
-    # def student_view_aside(self, block, context=None):  # pylint: disable=unused-argument
-    #     """
-    #     Allow the thumbs up/down-voting to work as an Aside as well as an XBlock.
-    #     """
-    #     fragment = self.student_view(context)
-    #     fragment.initialize_js('ThumbsAside')
-    #     return fragment

--- a/setup.py
+++ b/setup.py
@@ -89,10 +89,6 @@ setup(
             # Workbench specific
             'debugchild = workbench.blocks:DebuggingChildBlock',
         ],
-        'xblock_asides.v1': [
-            # Thumbs example
-            'thumbs_aside = sample_xblocks.thumbs:ThumbsAside',
-        ]
     },
     package_data=package_data,
 )


### PR DESCRIPTION
While developing an XBlock, the thumbs aside is no longer shown on the student view for every XBlock. 

Removing the aside definition was the only way that seemed obvious for disabling that demonstration aside, but it was necessary in order to be able to develop without the consistent reminder of functionality that I was neither using nor wanted. In the interest of providing a smooth on-boarding experience for new XBlock developers, I thought that it might make sense to remove the thumbs aside from the default configuration of the XBlock SDK. This way, developers who do not have an interest in developing asides or ensuring conformity with asides do not have to educate themselves about them. 