### PR TITLE
Reference existing documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,10 @@ Making your own XBlock
 ----------------------
 
 Making an XBlock involves creating a Python class that conforms to the XBlock 
-specification. See the sample_xblocks directory for examples and the 
-XBlock tutorial for a full walk-through: http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/index.html
+specification. See the sample_xblocks directory for examples and 
+`the XBlock tutorial`_ for a full walk-through.
+
+.. _the XBlock tutorial: http://edx.readthedocs.org/projects/xblock-tutorial
 
 We provide a script to create a new XBlock project to help you get started.
 Run bin/workbench-make-xblock in a directory where you want to create your XBlock
@@ -111,16 +113,20 @@ own instance of Open edX, or released to the wider community).
 
 
 Example XBlocks
-----------------
+---------------
 
 Included in this repository are some example XBlocks that demonstrate how to use 
 various aspects of the XBlock SDK. You can see a more detailed description of 
-those examples in the readme located in that repository: https://github.com/edx/xblock-sdk/blob/master/sample_xblocks/README.rst
+those examples in `the readme`_ located in that repository: 
+
 
 There is a rich community of XBlock developers that have put together a large 
 number of XBlocks that have been used in various contexts, mostly on the edx-platform. 
-You can see examples of what that community has done in the edx-platform wiki: 
-https://github.com/edx/edx-platform/wiki/List-of-XBlocks
+You can see examples of what that community has done in the `edx-platform wiki`_.
+
+
+.. _the readme: https://github.com/edx/xblock-sdk/blob/master/sample_xblocks/README.rst
+.. _edx-platform wiki: https://github.com/edx/edx-platform/wiki/List-of-XBlocks
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -84,9 +84,9 @@ as the default does.
 Making your own XBlock
 ----------------------
 
-Making an XBlock can be as simple as creating a Python class with a few
-specific methods.  The ``thumbs`` XBlock demonstrates an XBlock with state,
-views, and input handling.
+Making an XBlock involves creating a Python class that conforms to the XBlock 
+specification. See the sample_xblocks directory for examples and the 
+XBlock tutorial for a full walk-through: http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/index.html
 
 We provide a script to create a new XBlock project to help you get started.
 Run bin/workbench-make-xblock in a directory where you want to create your XBlock
@@ -110,13 +110,17 @@ own instance of Open edX, or released to the wider community).
 .. _XBlock review guidelines: https://openedx.atlassian.net/wiki/display/OPEN/XBlock+review+guidelines
 
 
-External XBlocks
+Example XBlocks
 ----------------
 
-We have been moving towards hosting XBlocks in external repositories, some of
-which have been installed and will appear in the workbench:
+Included in this repository are some example XBlocks that demonstrate how to use 
+various aspects of the XBlock SDK. You can see a more detailed description of 
+those examples in the readme located in that repository: https://github.com/edx/xblock-sdk/blob/master/sample_xblocks/README.rst
 
-ACID XBlock: https://github.com/edx/acid-block
+There is a rich community of XBlock developers that have put together a large 
+number of XBlocks that have been used in various contexts, mostly on the edx-platform. 
+You can see examples of what that community has done in the edx-platform wiki: 
+https://github.com/edx/edx-platform/wiki/List-of-XBlocks
 
 
 License

--- a/sample_xblocks/README.rst
+++ b/sample_xblocks/README.rst
@@ -4,19 +4,32 @@ Demo XBlocks
 This package contains some sample XBlocks to illustrate the capabilities of
 the XBlock specification. The following blocks are included:
 
-  * **helloworld_demo:** A block which simply displays the text "Hello World"
+  * **basic.content:HelloWorldBlock** A block which simply displays the text "Hello World"
 
-  * **html_demo:** A block which displays a specified block of HTML text
+  * **basic.content:AllScopesBlock** A block which demonstrates the scopes that come built in with XBlock
 
-  * **sequence_demo:** A container block which displays its children in a tabbed layout
+  * **basic.content:HtmlBlock** A block which displays a specified block of HTML text
 
-  * **vertical_demo:** A container block which displays its children in a vertical list
+  * **basic.structure:Sequence** A container block which displays its children in a tabbed layout
 
-  * **sidebar_demo:** A variant of the vertical block
+  * **basic.structure:VerticalBlock** A container block which displays its children in a vertical list
 
-  * **problem_demo:** A block which presents a problem and grades student responses
+  * **basic.structure:SidebarBlock** A variant of the vertical block
 
-  * **slider_demo:** A block which presents a slider and remembers the student's setting
+  * **basic.problem:ProblemBlock** A block which presents a problem and grades student responses
 
-  * **view_counter:** A block which shows the total number of times it has been viewed
+  * **basic.problem:TextInputBlock** 
 
+  * **basic.problem:EqualityCheckerBlock** 
+
+  * **basic.problem:AttemptScoreboardBlock** 
+
+  * **basic.slider:Slider** A block which presents a slider and remembers the student's setting
+
+  * **basic.view_counter:ViewCounter** 
+
+  * **basic.thumbs:ThumbsBlock** A block which shows the total number of times it has been viewed
+
+  * **basic.filethumbs:FileThumbsBlock** 
+
+Each of these blocks can be referenced in scenarios using a keyword in XML that is specified in the "entry_points" attribute of the setup tuple. 

--- a/sample_xblocks/README.rst
+++ b/sample_xblocks/README.rst
@@ -2,13 +2,24 @@ Demo XBlocks
 ============
 
 This package contains some sample XBlocks to illustrate the capabilities of
-the XBlock specification. The following blocks are included:
+the XBlock specification. Please note that although basic.problem is included as an illustrative example, 
+it does NOT demonstrate how problems are implemented in the edx-platform runtime. 
 
-  * **basic.content:HelloWorldBlock** A block which simply displays the text "Hello World"
+The following blocks have workbench scenarios displayed by default:
+
 
   * **basic.content:AllScopesBlock** A block which demonstrates the scopes that come built in with XBlock
 
+  * **basic.content:HelloWorldBlock** A block which simply displays the text "Hello World"
+
   * **basic.content:HtmlBlock** A block which displays a specified block of HTML text
+
+  * **basic.problem:ProblemBlock** A block which presents a problem and grades student responses
+
+  * **thumbs.thumbs:ThumbsBlock** A block which shows the total number of times it has been viewed
+
+
+The following problems are included in the sdk as illustration of the possibilities of XBlock:
 
   * **basic.structure:Sequence** A container block which displays its children in a tabbed layout
 
@@ -16,11 +27,13 @@ the XBlock specification. The following blocks are included:
 
   * **basic.structure:SidebarBlock** A variant of the vertical block
 
-  * **basic.problem:ProblemBlock** A block which presents a problem and grades student responses
-
   * **basic.problem:TextInputBlock** 
 
+  * **basic.problem:InputBlock**
+
   * **basic.problem:EqualityCheckerBlock** 
+
+  * **basic.problem:CheckerBlock** 
 
   * **basic.problem:AttemptScoreboardBlock** 
 
@@ -28,8 +41,7 @@ the XBlock specification. The following blocks are included:
 
   * **basic.view_counter:ViewCounter** 
 
-  * **basic.thumbs:ThumbsBlock** A block which shows the total number of times it has been viewed
-
-  * **basic.filethumbs:FileThumbsBlock** 
+  * **filethumbs.filethumbs:FileThumbsBlock** 
 
 Each of these blocks can be referenced in scenarios using a keyword in XML that is specified in the "entry_points" attribute of the setup tuple. 
+

--- a/sample_xblocks/basic/problem.py
+++ b/sample_xblocks/basic/problem.py
@@ -1,5 +1,9 @@
 """Problem XBlock, and friends.
 
+Please note that this is a demonstrative implementation of how XBlocks can
+be used, and is not an example of how problems are implemented in the 
+edx-platform runtime. 
+
 These implement a general mechanism for problems containing input fields
 and checkers, wired together in interesting ways.
 


### PR DESCRIPTION
Updated the README to refer to existing documentation, including the XBlock tutorial, external XBlocks, and sample XBlocks