### PR TITLE
removed the thumbs display from default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         ],
         'xblock_asides.v1': [
             # Thumbs example
-            'thumbs_aside = sample_xblocks.thumbs:ThumbsAside',
+            # 'thumbs_aside = sample_xblocks.thumbs:ThumbsAside',
         ]
     },
     package_data=package_data,


### PR DESCRIPTION
This removes the thumbs aside from displaying by default.

Note this pull request was originally containing a description for removing the acid aside, which is actually contained in [https://github.com/edx/xblock-sdk/pull/91]
