### PR TITLE
removed the Acid Block from the test requirements

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,5 +5,3 @@ pep8
 rednose
 bok_choy==0.3.3
 
-# Acid xblock
--e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock


### PR DESCRIPTION


Removes the Acid Block from the test requirements in the XBlock SDK. The justification is as follows:

(1) The status quo requires developers to break from default testing procedure in order to use the Acid Block effectively as a testing tool, so asking developers to install the Acid Block separately from a default installation is not an unreasonable requirement.

As a reminder, the Acid Block does not integrate with the testing framework that developers are using in the XBlock SDK because it does not produce a little green dot on the command line when running "make test". The acid block is currently installed by default when the developer uses "make" or "make install", because those commands install all of the test dependencies, including the acid block.

(2) Furthermore, the Aside functionality within the block causes it to display prominently during non-testing, which means that it's installation as default behaviour is causing a lot of confusion and annoyance.

See full discussion from edx-code here: https://groups.google.com/forum/#!topic/edx-code/r-xEVGNjJhM
