### PR TITLE
added new dependency to installation instructions in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ This code runs on Python 2.7.
 
 #.  Install standard development libraries. Here's how you do it on Ubuntu or Debian::
 
-        $ sudo apt-get install python-dev libxml2-dev libxslt-dev lib32z1-dev
+        $ sudo apt-get install python-dev libxml2-dev libxslt-dev lib32z1-dev libjpeg62-dev
 
 #.  Get a local copy of this repo.
 


### PR DESCRIPTION
This is probably from the upgrade to django 1.8, but another dependency appears that needed to be installed outside of pip. 