### PR TITLE
two scenarios

### DIFF
--- a/prototype/{{cookiecutter.short_name}}/{{cookiecutter.short_name}}/{{cookiecutter.short_name}}.py
+++ b/prototype/{{cookiecutter.short_name}}/{{cookiecutter.short_name}}/{{cookiecutter.short_name}}.py
@@ -59,6 +59,9 @@ class {{cookiecutter.class_name}}(XBlock):
         """A canned scenario for display in the workbench."""
         return [
             ("{{cookiecutter.class_name}}",
+             """<{{cookiecutter.short_name|lower}}/>
+             """),
+            ("Multiple {{cookiecutter.class_name}}",
              """<vertical_demo>
                 <{{cookiecutter.short_name|lower}}/>
                 <{{cookiecutter.short_name|lower}}/>


### PR DESCRIPTION
This shows the default prototype XBlock without an intermediary as well as displaying an LMS-centric view of the same XBlock, as discussed in https://github.com/edx/xblock-sdk/pull/79