### PR TITLE
Fix: don't touch the DB at import time

### DIFF
--- a/workbench/scenarios.py
+++ b/workbench/scenarios.py
@@ -75,4 +75,13 @@ def init_scenarios():
     for class_name, cls in sorted(XBlock.load_classes(fail_silently=False)):
         add_class_scenarios(class_name, cls, fail_silently=False)
 
-init_scenarios()
+def get_scenarios():
+    """
+    Return SCENARIOS, initializing it if required.
+    """
+    if not SCENARIOS and not get_scenarios.initialized:
+        init_scenarios()
+        get_scenarios.initialized = True
+    return SCENARIOS
+
+get_scenarios.initialized = False

--- a/workbench/test/test_scenarios.py
+++ b/workbench/test/test_scenarios.py
@@ -29,7 +29,7 @@ class ScenarioTest(unittest.TestCase):
         a_tags = list(html.xpath('//a'))
 
         # Load the loaded_scenarios from the classes.
-        loaded_scenarios = scenarios.SCENARIOS.values()
+        loaded_scenarios = scenarios.get_scenarios().values()
 
         # We should have an <a> tag for each scenario.
         assert_equals(len(a_tags), len(loaded_scenarios))
@@ -44,7 +44,7 @@ class ScenarioTest(unittest.TestCase):
         assert all("<vertical_demo></vertical_demo>" not in scen.xml for scen in loaded_scenarios)
         assert all("<vertical_demo/>" not in scen.xml for scen in loaded_scenarios)
 
-    @ddt.data(*scenarios.SCENARIOS.keys())
+    @ddt.data(*scenarios.get_scenarios().keys())
     def test_scenario(self, scenario_id):
         """A very shallow test, just to see if the scenario loads all its blocks.
 

--- a/workbench/views.py
+++ b/workbench/views.py
@@ -18,7 +18,7 @@ from xblock.exceptions import NoSuchUsage
 
 from .models import XBlockState
 from .runtime import WorkbenchRuntime, reset_global_state
-from .scenarios import SCENARIOS
+from .scenarios import get_scenarios
 from xblock.plugin import PluginMissingError
 
 
@@ -37,7 +37,7 @@ def get_student_id(request):
 
 def index(_request):
     """Render `index.html`"""
-    the_scenarios = sorted(SCENARIOS.items())
+    the_scenarios = sorted(get_scenarios().items())
     return render_to_response('workbench/index.html', {
         'scenarios': [(desc, scenario.description) for desc, scenario in the_scenarios]
     })
@@ -56,7 +56,7 @@ def show_scenario(request, scenario_id, view_name='student_view', template='work
     log.info("Start show_scenario %r for student %s", scenario_id, student_id)
 
     try:
-        scenario = SCENARIOS[scenario_id]
+        scenario = get_scenarios()[scenario_id]
     except KeyError:
         raise Http404
 


### PR DESCRIPTION
@nedbat Your commit 6b5b6e277a8a13264a9b385c3b943948eee67743 is causing trouble for our XBlocks that run integration tests inside the xblock-sdk runtime (e.g. most xblocks that use `xblock-utils`). The xblock-utils integration test running imports `workbench.scenarios` in order to inject custom scenarios for testing, but that PR has changed workbench.scenarios so that it uses the database at import time, before the test database is configured - which causes DB errors when we try to run tests.

As a matter of principle, the database should not be used at import time, for reasons like this.

This is a proposed fix.

CC @itsjeyd 