### PR TITLE
mattdrayer/update-xblock-reference: Bump to 0.4.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ lazy
 
 # XBlock
 # This is not in/from PyPi, since it moves fast
--e git+https://github.com/edx/XBlock.git@xblock-0.4.1#egg=XBlock==0.4.1
+-e git+https://github.com/edx/XBlock.git@xblock-0.4.7#egg=XBlock==0.4.7
 #-e ../XBlock
 
 fs

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ package_data.update(find_package_data("workbench", ["static", "templates"]))
 
 setup(
     name='xblock-sdk',
-    version='0.1.1',
+    version='0.1.2',
     description='XBlock SDK',
     packages=[
         'sample_xblocks',


### PR DESCRIPTION
@nedbat @doctoryes, FYI -- bumping XBlock reference from 0.4.1 to 0.4.7 in order to be able to take advantage of the new I18N support here: https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/66