### PR TITLE
Add Dockerfile to support building and running the XBlock workbench via a Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM phusion/baseimage:latest
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    lib32z1-dev \
+    libjpeg62-dev \
+    libxml2-dev \
+    libxslt-dev \
+    python-dev \
+    python-setuptools \
+    xz-utils \
+&& rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /usr/local/src/xblock-sdk
+WORKDIR /usr/local/src/xblock-sdk
+ADD . .
+RUN easy_install pip
+RUN make install
+ENTRYPOINT ["python", "manage.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ WORKDIR /usr/local/src/xblock-sdk
 ADD . .
 RUN easy_install pip
 RUN make install
+EXPOSE 8000
 ENTRYPOINT ["python", "manage.py"]
+CMD ["runserver", "0.0.0.0:8000"]

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,20 @@ This code runs on Python 2.7.
 
 #.  Open a web browser to: http://127.0.0.1:8000
 
+Docker
+------
+
+Alternatively, you can build and run the xblock-sdk in Docker.
+
+After cloning this repository locally, go into the repository directory and build the Docker image::
+
+        $ docker build -t xblock-sdk .
+
+You can then run the locally-built version using the following command::
+
+        $ docker run -d -p 8000:8000 --name xblock-sdk xblock-sdk
+
+You should now be able to access the XBlock SDK environment in your browser at http://localhost:8000
 
 Testing
 --------


### PR DESCRIPTION
Uses https://github.com/phusion/baseimage-docker as a minimal Ubuntu base image to make the container as slim as possible. 

Added instructions to the README. 

Using this in conjunction with https://github.com/jbarciauskas/cookiecutter-xblock makes creating a new XBlock and testing it in the workbench very quick. 