### PR TITLE
Fixed logging misconfiguration

### DIFF
--- a/workbench/settings.py
+++ b/workbench/settings.py
@@ -168,7 +168,7 @@ LOGGING = {
     'handlers': {
         'null': {
             'level': 'DEBUG',
-            'class': 'django.utils.log.NullHandler',
+            'class': 'logging.NullHandler',
         },
         'logfile': {
             'level': 'DEBUG',


### PR DESCRIPTION
**Description:** This PR fixes broken logging configuration.

```
ValueError: Unable to configure handler 'null': Cannot resolve 'django.utils.log.NullHandler': No module named NullHandler
```