### PR TITLE
Migrate on brand new install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ requirements: ## install development environment requirements
 	pip install -qr requirements/local.txt --exists-action w
 
 install: requirements
+	python manage.py migrate --noinput
 
 test: clean ## run tests in the current virtualenv
 	pip install -qr requirements/local.txt --exists-action w ## Install sample xblocks


### PR DESCRIPTION
The `make install` command (n°4 in the README, section "Installation") simply install requirements but do not apply migrations.

If a brand new user do not execute the `python manage.py migrate` command, he won't be able to execute the `python manage.py runserver` (n°5 in the README, section "Installation") succesfully.

We can add the `python manage.py migrate --noinput` command directly into the Makefile in order to solve this issue.