### PR TITLE
Add support for the LTI Consumer XBlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ geckodriver.log
 workbench/static/djpyfs/
 workbench.test.*
 
+### Developer Settings
+private.py
+
 # Documentation
 doc/_build
 .pip_cache

--- a/workbench/services.py
+++ b/workbench/services.py
@@ -1,0 +1,30 @@
+"""
+Module contains various XBlock services for the workbench.
+"""
+from __future__ import unicode_literals
+
+from django.conf import settings
+
+
+class SettingsService(object):
+    """
+    Allows server-wide configuration of XBlocks on a per-type basis.
+
+    The service is copied as-is from the Open edX platform:
+
+      - `edx-platform/common/lib/xmodule/xmodule/services.py`
+    """
+    xblock_settings_bucket_selector = 'block_settings_key'
+
+    def get_settings_bucket(self, block, default=None):
+        """ Gets xblock settings dictionary from settings. """
+        if not block:
+            raise ValueError("Expected XBlock instance, got {block} of type {type}".format(
+                block=block,
+                type=type(block)
+            ))
+
+        actual_default = default if default is not None else {}
+        xblock_settings_bucket = getattr(block, self.xblock_settings_bucket_selector, block.unmixed_class.__name__)
+        xblock_settings = settings.XBLOCK_SETTINGS if hasattr(settings, "XBLOCK_SETTINGS") else {}
+        return xblock_settings.get(xblock_settings_bucket, actual_default)

--- a/workbench/settings.py
+++ b/workbench/settings.py
@@ -203,6 +203,12 @@ WORKBENCH = {
     ),
 
     'services': {
-        'fs': 'xblock.reference.plugins.FSService'
+        'fs': 'xblock.reference.plugins.FSService',
+        'settings': 'workbench.services.SettingsService',
     }
 }
+
+try:
+    from .private import *  # pylint: disable=wildcard-import,import-error,useless-suppression
+except ImportError:
+    pass

--- a/workbench/test/test_runtime.py
+++ b/workbench/test/test_runtime.py
@@ -76,6 +76,22 @@ class TestScenarioIds(TestCase):
         self.assertEqual(self.id_mgr.get_usage_id_from_aside(aside_usage), usage_id)
 
 
+class WorkbenchRuntimeTests(TestCase):
+    """
+    Tests for the WorkbenchRuntime.
+    """
+
+    def test_lti_consumer_xblock_requirements(self):
+        """
+        The LTI Consumer XBlock expects a lot of values from the LMS Runtime,
+        this test ensures that those requirements fulfilled.
+        """
+        runtime = WorkbenchRuntime('test_user')
+        assert runtime.get_real_user(object()), 'The LTI Consumer XBlock needs this method.'
+        assert runtime.hostname, 'The LTI Consumer XBlock needs this property.'
+        assert runtime.anonymous_student_id, 'The LTI Consumer XBlock needs this property.'
+
+
 class TestKVStore(TestCase):
     """
     Test the Workbench KVP Store


### PR DESCRIPTION
The LTI Consumer XBlock expects a couple of extra fields from the runtime, adding those fields so the XBlock can be run from the workbench.

This pull request is required for my work on the LTI Consumer XBlock: https://github.com/edx/xblock-lti-consumer/pull/44