### PR TITLE
Ensure that request.body is bytes in Python 3

### DIFF
--- a/sample_xblocks/basic/test/test_problem.py
+++ b/sample_xblocks/basic/test/test_problem.py
@@ -23,7 +23,7 @@ def make_request(body):
 
 def text_of_response(response):
     """Return the text of response."""
-    return "".join(response.app_iter)
+    return b"".join(response.app_iter)
 
 
 @pytest.mark.django_db

--- a/sample_xblocks/basic/test/test_problem.py
+++ b/sample_xblocks/basic/test/test_problem.py
@@ -16,7 +16,7 @@ from xblock.test.tools import assert_equals
 def make_request(body):
     """Mock request method."""
     request = webob.Request({})
-    request.body = body
+    request.body = body.encode('utf-8')
     request.method = "POST"
     return request
 


### PR DESCRIPTION
Makes __sample_xblocks/basic/test/test_problem.py__ test pass on Python 2.7 and 3.6.

See error at https://travis-ci.org/edx/xblock-sdk/jobs/498946135#L345

Related to https://openedx.atlassian.net/browse/INCR-103