### PR TITLE
Improve docker layer caching with pip installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,15 @@ RUN apt-get update && apt-get install -y \
     python-setuptools \
     xz-utils \
 && rm -rf /var/lib/apt/lists/*
+
+RUN easy_install pip
+ADD requirements/dev.txt /tmp/dev.txt
+RUN pip install -r /tmp/dev.txt \
+&& rm /tmp/dev.txt
+
 RUN mkdir -p /usr/local/src/xblock-sdk
 WORKDIR /usr/local/src/xblock-sdk
 ADD . .
-RUN easy_install pip
 RUN make install
 EXPOSE 8000
 ENTRYPOINT ["python", "manage.py"]


### PR DESCRIPTION
by:
- installing `pip` sooner
  - and caching the layer
- preemptively installing a copy of
  `requirements/dev.txt`
  - and caching it

Otherwise, the `ADD . .` build step breaks its cache very easily
(if any file in the project directory changes), which means any steps
that follow will seldom be cached. This is particularly problematic with
the `pip` installation, as this needs constantly rebuilt at an expensive
time hit.