### PR TITLE
INCR-103 | Fix bytes vs. str bugs in xblock-sdk under Python 3

### DIFF
--- a/sample_xblocks/filethumbs/filethumbs.py
+++ b/sample_xblocks/filethumbs/filethumbs.py
@@ -75,12 +75,13 @@ class FileThumbsBlock(XBlock):
         """
 
         # Load the HTML fragment from within the package and fill in the template
-        html_str = pkg_resources.resource_string(__name__, "static/html/thumbs.html")
+        html_str = pkg_resources.resource_string(__name__,
+                                                 "static/html/thumbs.html").decode('utf-8')
         frag = Fragment(text_type(html_str))
 
         if not self.fs.exists(u"thumbsvotes.json"):
             with self.fs.open(u'thumbsvotes.json', 'wb') as file_output:
-                json.dump({'up': 0, 'down': 0}, file_output)
+                file_output.write(json.dumps({'up': 0, 'down': 0}).encode())
                 file_output.close()
 
         votes = json.load(self.fs.open(u"thumbsvotes.json"))
@@ -88,11 +89,12 @@ class FileThumbsBlock(XBlock):
         self.downvotes = votes['down']
 
         # Load the CSS and JavaScript fragments from within the package
-        css_str = pkg_resources.resource_string(__name__, "static/css/thumbs.css")
+        css_str = pkg_resources.resource_string(__name__,
+                                                "static/css/thumbs.css").decode('utf-8')
         frag.add_css(text_type(css_str))
 
         js_str = pkg_resources.resource_string(__name__,
-                                               "static/js/src/thumbs.js")
+                                               "static/js/src/thumbs.js").decode('utf-8')
         frag.add_javascript(text_type(js_str))
 
         with self.fs.open(u'uparrow.png', 'wb') as file_output:
@@ -136,7 +138,9 @@ class FileThumbsBlock(XBlock):
             self.downvotes += 1
 
         with self.fs.open(u'thumbsvotes.json', 'wb') as file_output:
-            json.dump({'up': self.upvotes, 'down': self.downvotes}, file_output)
+            file_output.write(
+                json.dumps({'up': self.upvotes, 'down': self.downvotes}).encode()
+            )
 
         self.voted = True
 

--- a/sample_xblocks/thumbs/thumbs.py
+++ b/sample_xblocks/thumbs/thumbs.py
@@ -38,15 +38,17 @@ class ThumbsBlockBase(object):
         """
 
         # Load the HTML fragment from within the package and fill in the template
-        html_str = pkg_resources.resource_string(__name__, "static/html/thumbs.html")
+        html_str = pkg_resources.resource_string(__name__,
+                                                 "static/html/thumbs.html").decode('utf-8')
         frag = Fragment(text_type(html_str).format(block=self))
 
         # Load the CSS and JavaScript fragments from within the package
-        css_str = pkg_resources.resource_string(__name__, "static/css/thumbs.css")
+        css_str = pkg_resources.resource_string(__name__,
+                                                "static/css/thumbs.css").decode('utf-8')
         frag.add_css(text_type(css_str))
 
         js_str = pkg_resources.resource_string(__name__,
-                                               "static/js/src/thumbs.js")
+                                               "static/js/src/thumbs.js").decode('utf-8')
         frag.add_javascript(text_type(js_str))
 
         frag.initialize_js('ThumbsBlock')

--- a/workbench/test/test_views.py
+++ b/workbench/test/test_views.py
@@ -243,7 +243,6 @@ def test_xblock_with_handlers():
     ]
 
     for url, expected in zip(urls, expecteds):
-        print(type(url))
         print(url)   # so we can see which one failed, if any.
         response = client.get(url)
         assert_equals(response.status_code, 200)

--- a/workbench/test/test_views.py
+++ b/workbench/test/test_views.py
@@ -103,10 +103,10 @@ def test_xblock_with_handler():
     # Initially, the data is the default.
     response = client.get("/view/testit/")
     response_content = response.content.decode('utf-8')
-    assert_true(
-        "The data: u'def'." in response_content
-        or "The data: 'def'." in response_content
-    )
+
+    expected = u"The data: %r." % u"def"
+    assert_true(expected in response_content)
+
     parsed = response_content.split(':::')
     assert_equals(len(parsed), 3)
     handler_url = parsed[1]


### PR DESCRIPTION
This PR addresses the remaining failing tests from [INCR-103](https://openedx.atlassian.net/browse/INCR-103). I've tested them on Python 3.6 and Python 2.7 and all tests are passing apart from the single skipped test, which was being skipped when I pulled master.

I don't have a lot of experience with maintaining compatibility between Python 2 and Python 3, so please let me know if there's anything I should have done differently. Most of the changes ended up being fairly straightforward, but I did want to call out the changes in `test_views.py` related to `webob.Response` – it looks like `webob` 1.7 introduced some backwards-incompatible changes for JSON responses, you can read more about it [here](https://docs.pylonsproject.org/projects/webob/en/1.7-branch/whatsnew-1.7.html#backwards-incompatibility). Just in case that's useful to someone else in the future.