### PR TITLE
BOM-470

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: latest
 language: python
 python:
     - 2.7
+    - 3.5
     - 3.6
     - 3.7
 env:
@@ -12,7 +13,7 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=quality
-    - python: 3.7
+    - python: 3.5
       env: TOXENV=quality
   exclude:
     - python: 2.7
@@ -20,7 +21,9 @@ matrix:
     - python: 2.7
       env: TOXENV=django21
   allow_failures:
+    - python: 3.6
     - python: 3.7
+
 
 addons:
     firefox: "52.0.1"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,4 +13,4 @@ requests==2.9.1
 pypng
 simplejson
 webob
-XBlock==1.1.1
+XBlock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,29 +13,32 @@ botocore==1.8.50          # via boto3, s3transfer
 chardet==3.0.4            # via binaryornot
 cookiecutter==0.9.0
 django-pyfs==2.0
-django==1.11.20
-docutils==0.14            # via botocore
+django==1.11.25
+docutils==0.15.2          # via botocore
 enum34==1.1.6             # via fs
 fs-s3fs==0.1.5
 fs==2.0.27                # via django-pyfs, fs-s3fs, xblock
 funcsigs==1.0.2           # via mock
 future==0.17.1            # via backports.os
-futures==3.2.0 ; python_version == "2.7"  # via s3transfer
+futures==3.3.0 ; python_version == "2.7"  # via s3transfer
 jinja2==2.10.1            # via cookiecutter
 jmespath==0.9.4           # via boto3, botocore
 lazy==1.1
 lxml==3.8.0
 markupsafe==1.1.1         # via jinja2, xblock
 mock==3.0.5               # via cookiecutter
-pypng==0.0.19
+pypng==0.0.20
 python-dateutil==2.8.0    # via botocore, xblock
-pytz==2019.1              # via django, fs, xblock
-pyyaml==5.1               # via cookiecutter, xblock
+pytz==2019.2              # via django, fs, xblock
+pyyaml==5.1.2             # via cookiecutter, xblock
 requests==2.9.1
 s3transfer==0.1.13        # via boto3
 simplejson==3.16.0
 six==1.10.0               # via django-pyfs, fs, fs-s3fs, mock, python-dateutil, xblock
-typing==3.6.6             # via fs
+typing==3.7.4.1           # via fs
 web-fragments==0.3.0      # via xblock
 webob==1.8.5
-xblock==1.1.1
+xblock==1.2.6
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.2.0        # via fs, lazy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
+-e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
 appdirs==1.4.3            # via fs
-astroid==1.5.3            # via pylint, pylint-celery
+astroid==1.6.6            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 backports.functools-lru-cache==1.5  # via astroid, isort, pylint
@@ -19,51 +19,55 @@ botocore==1.8.50          # via boto3, s3transfer
 chardet==3.0.4            # via binaryornot
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
-configparser==3.7.4       # via pydocstyle, pylint
+configparser==4.0.2       # via importlib-metadata, pydocstyle, pylint
+contextlib2==0.6.0        # via importlib-metadata
 cookiecutter==0.9.0
-coverage==4.5.3
+coverage==4.5.4
 ddt==1.2.1
 django-pyfs==2.0
-django==1.11.20
-docutils==0.14            # via botocore
-edx-lint==1.2.1
+django==1.11.25
+docutils==0.15.2          # via botocore
+edx-lint==1.4.0
 enum34==1.1.6             # via astroid, fs
 filelock==3.0.12          # via tox
 fs-s3fs==0.1.5
 fs==2.0.27                # via django-pyfs, fs-s3fs, xblock
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via backports.os
-futures==3.2.0 ; python_version == "2.7"  # via isort, s3transfer
-isort==4.3.20
+futures==3.3.0 ; python_version == "2.7"  # via isort, s3transfer
+importlib-metadata==0.23  # via pluggy, pytest, tox
+isort==4.3.21
 jinja2==2.10.1            # via cookiecutter
 jmespath==0.9.4           # via boto3, botocore
-lazy-object-proxy==1.4.1  # via astroid
+lazy-object-proxy==1.4.2  # via astroid
 lazy==1.1
 lxml==3.8.0
-mako==1.0.10
+mako==1.1.0
 markupsafe==1.1.1         # via jinja2, mako, xblock
 mccabe==0.6.1             # via pylint
 mock==3.0.5
-more-itertools==5.0.0     # via pytest
+more-itertools==5.0.0     # via pytest, zipp
 needle==0.5.0             # via bok-choy
 nose==1.3.7               # via needle
-pathlib2==2.3.3           # via pytest, pytest-django
-pillow==6.0.0             # via needle
-pluggy==0.11.0            # via pytest, tox
+packaging==19.2           # via pytest, tox
+pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
+pillow==6.1.0             # via needle
+pluggy==0.13.0            # via pytest, tox
 py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0
 pydocstyle==3.0.0
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
-pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pypng==0.0.19
+pylint-django==0.11.1     # via edx-lint
+pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
+pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.4.2          # via packaging
+pypng==0.0.20
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0             # via pytest-cov, pytest-django
+pytest-django==3.5.1
+pytest==4.6.5             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, xblock
-pytz==2019.1              # via django, fs, xblock
-pyyaml==5.1               # via cookiecutter, xblock
+pytz==2019.2              # via django, fs, xblock
+pyyaml==5.1.2             # via cookiecutter, xblock
 requests==2.9.1
 s3transfer==0.1.13        # via boto3
 scandir==1.10.0           # via pathlib2
@@ -71,14 +75,18 @@ selenium==3.4.1
 simplejson==3.16.0
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.10.0
-snowballstemmer==1.2.1    # via pydocstyle
+snowballstemmer==1.9.1    # via pydocstyle
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.12.1
-typing==3.6.6             # via fs
-virtualenv==16.6.0        # via tox
+tox==3.14.0
+typing==3.7.4.1           # via fs
+virtualenv==16.7.5        # via tox
 wcwidth==0.1.7            # via pytest
 web-fragments==0.3.0      # via xblock
 webob==1.8.5
-wrapt==1.11.1             # via astroid
-xblock==1.1.1
+wrapt==1.11.2             # via astroid
+xblock==1.2.6
+zipp==0.6.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.2.0        # via fs, lazy

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,24 +4,24 @@
 #
 #    make upgrade
 #
-astroid==1.5.3            # via pylint, pylint-celery
+astroid==1.6.6            # via pylint, pylint-celery
 backports.functools-lru-cache==1.5  # via astroid, isort, pylint
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
-configparser==3.7.4       # via pydocstyle, pylint
-edx-lint==1.2.1
+configparser==4.0.2       # via pydocstyle, pylint
+edx-lint==1.4.0
 enum34==1.1.6             # via astroid
-futures==3.2.0 ; python_version == "2.7"  # via isort
-isort==4.3.20
-lazy-object-proxy==1.4.1  # via astroid
+futures==3.3.0 ; python_version == "2.7"  # via isort
+isort==4.3.21
+lazy-object-proxy==1.4.2  # via astroid
 mccabe==0.6.1             # via pylint
 pycodestyle==2.5.0
 pydocstyle==3.0.0
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
-pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint-django==0.11.1     # via edx-lint
+pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
+pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 singledispatch==3.4.0.3   # via astroid, pylint
 six==1.10.0
-snowballstemmer==1.2.1    # via pydocstyle
-wrapt==1.11.1             # via astroid
+snowballstemmer==1.9.1    # via pydocstyle
+wrapt==1.11.2             # via astroid

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -10,4 +10,4 @@ tox                       # Virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
 
 # Acid xblock
--e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
+-e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
--e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
+-e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
 appdirs==1.4.3            # via fs
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
@@ -15,51 +15,60 @@ boto3==1.4.8              # via fs-s3fs
 boto==2.39.0
 botocore==1.8.50          # via boto3, s3transfer
 chardet==3.0.4            # via binaryornot
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0        # via importlib-metadata
 cookiecutter==0.9.0
-coverage==4.5.3
+coverage==4.5.4
 ddt==1.2.1
 django-pyfs==2.0
-docutils==0.14            # via botocore
+docutils==0.15.2          # via botocore
 enum34==1.1.6             # via fs
 filelock==3.0.12          # via tox
 fs-s3fs==0.1.5
 fs==2.0.27                # via django-pyfs, fs-s3fs, xblock
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via backports.os
-futures==3.2.0 ; python_version == "2.7"  # via s3transfer
+futures==3.3.0 ; python_version == "2.7"  # via s3transfer
+importlib-metadata==0.23  # via pluggy, pytest, tox
 jinja2==2.10.1            # via cookiecutter
 jmespath==0.9.4           # via boto3, botocore
 lazy==1.1
 lxml==3.8.0
-mako==1.0.10
+mako==1.1.0
 markupsafe==1.1.1         # via jinja2, mako, xblock
 mock==3.0.5
-more-itertools==5.0.0     # via pytest
+more-itertools==5.0.0     # via pytest, zipp
 needle==0.5.0             # via bok-choy
 nose==1.3.7               # via needle
-pathlib2==2.3.3           # via pytest, pytest-django
-pillow==6.0.0             # via needle
-pluggy==0.11.0            # via pytest, tox
+packaging==19.2           # via pytest, tox
+pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
+pillow==6.1.0             # via needle
+pluggy==0.13.0            # via pytest, tox
 py==1.8.0                 # via pytest, tox
-pypng==0.0.19
+pyparsing==2.4.2          # via packaging
+pypng==0.0.20
 pytest-cov==2.7.1
-pytest-django==3.4.8
-pytest==4.5.0             # via pytest-cov, pytest-django
+pytest-django==3.5.1
+pytest==4.6.5             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via botocore, xblock
-pytz==2019.1              # via django, fs, xblock
-pyyaml==5.1               # via cookiecutter, xblock
+pytz==2019.2              # via django, fs, xblock
+pyyaml==5.1.2             # via cookiecutter, xblock
 requests==2.9.1
 s3transfer==0.1.13        # via boto3
 scandir==1.10.0           # via pathlib2
 selenium==3.4.1
 simplejson==3.16.0
-six==1.10.0               # via bok-choy, django-pyfs, fs, fs-s3fs, mock, pathlib2, pytest, python-dateutil, tox, xblock
+six==1.10.0               # via bok-choy, django-pyfs, fs, fs-s3fs, mock, more-itertools, packaging, pathlib2, pytest, python-dateutil, tox, xblock
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.12.1
-typing==3.6.6             # via fs
-virtualenv==16.6.0        # via tox
+tox==3.14.0
+typing==3.7.4.1           # via fs
+virtualenv==16.7.5        # via tox
 wcwidth==0.1.7            # via pytest
 web-fragments==0.3.0      # via xblock
 webob==1.8.5
-xblock==1.1.1
+xblock==1.2.6
+zipp==0.6.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.2.0        # via fs, lazy

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,18 +4,27 @@
 #
 #    make upgrade
 #
-certifi==2019.3.9         # via requests
+certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-coverage==4.5.3           # via codecov
+configparser==4.0.2       # via importlib-metadata
+contextlib2==0.6.0        # via importlib-metadata
+coverage==4.5.4           # via codecov
 filelock==3.0.12          # via tox
 idna==2.8                 # via requests
-pluggy==0.11.0            # via tox
+importlib-metadata==0.23  # via pluggy, tox
+more-itertools==5.0.0     # via zipp
+packaging==19.2           # via tox
+pathlib2==2.3.5           # via importlib-metadata
+pluggy==0.13.0            # via tox
 py==1.8.0                 # via tox
+pyparsing==2.4.2          # via packaging
 requests==2.22.0          # via codecov
-six==1.12.0               # via tox
+scandir==1.10.0           # via pathlib2
+six==1.12.0               # via more-itertools, packaging, pathlib2, tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.12.1
-urllib3==1.25.3           # via requests
-virtualenv==16.6.0        # via tox
+tox==3.14.0
+urllib3==1.25.6           # via requests
+virtualenv==16.7.5        # via tox
+zipp==0.6.0               # via importlib-metadata

--- a/sample_xblocks/basic/test/test_problem.py
+++ b/sample_xblocks/basic/test/test_problem.py
@@ -8,7 +8,6 @@ import json
 
 import pytest
 import webob
-from xblock.test.tools import assert_equals
 
 from workbench.runtime import WorkbenchRuntime
 
@@ -49,4 +48,4 @@ def test_problem_submission():
     json_data = json.dumps({"vote_count": [{"name": "input", "value": "4"}]})
     resp = runtime.handle(problem, 'check', make_request(json_data))
     resp_data = json.loads(text_of_response(resp))
-    assert_equals(resp_data['checkResults']['votes_named'], True)
+    assert resp_data['checkResults']['votes_named'] == True

--- a/sample_xblocks/basic/test/test_view_counter.py
+++ b/sample_xblocks/basic/test/test_view_counter.py
@@ -6,7 +6,6 @@ from mock import Mock
 from six.moves import range
 from xblock.runtime import DictKeyValueStore, KvsFieldData
 from xblock.test.tools import TestRuntime as Runtime  # Workaround for pytest trying to collect "TestRuntime" as a test
-from xblock.test.tools import assert_equals, assert_in
 
 from sample_xblocks.basic.view_counter import ViewCounter
 
@@ -17,11 +16,11 @@ def test_view_counter_state():
     runtime = Runtime(services={'field-data': field_data})
     tester = ViewCounter(runtime, scope_ids=Mock())
 
-    assert_equals(tester.views, 0)
+    assert tester.views == 0
 
     # View the XBlock five times
     for i in range(5):
         generated_html = tester.student_view({})
         # Make sure the html fragment we're expecting appears in the body_html
-        assert_in('<span class="views">{0}</span>'.format(i + 1), generated_html.body_html())
-        assert_equals(tester.views, i + 1)
+        assert('<span class="views">{0}</span>'.format(i + 1) in generated_html.body_html())
+        assert tester.views == i + 1

--- a/workbench/test/test_scenarios.py
+++ b/workbench/test/test_scenarios.py
@@ -8,7 +8,6 @@ import unittest
 
 import lxml.html
 import pytest
-from xblock.test.tools import assert_equals
 
 from django.core.urlresolvers import reverse
 from django.test.client import Client
@@ -41,7 +40,7 @@ class ScenarioTest(unittest.TestCase):
         loaded_scenarios = list(scenarios.get_scenarios().values())
 
         # We should have an <a> tag for each scenario.
-        assert_equals(len(a_tags), len(loaded_scenarios))
+        assert len(a_tags) == len(loaded_scenarios)
 
         # We should have at least one scenario with a vertical tag, since we use
         # empty verticals as our canary in the coal mine that something has gone

--- a/workbench/test/test_views.py
+++ b/workbench/test/test_views.py
@@ -12,13 +12,13 @@ from xblock.core import Scope, String, XBlock
 from xblock.exceptions import DisallowedFileError
 from xblock.fragment import Fragment
 from xblock.runtime import NoSuchHandlerError
-from xblock.test.tools import assert_equals, assert_in, assert_raises, assert_raises_regexp, assert_true
 
 from django.core.urlresolvers import reverse
 from django.test.client import Client
 
 from workbench import scenarios
 from workbench.runtime import ID_MANAGER
+
 
 pytestmark = pytest.mark.django_db  # pylint: disable=invalid-name
 
@@ -57,7 +57,7 @@ def test_unknown_scenario():
     client = Client()
 
     response = client.get(reverse('scenario', args=('unknown_scenario', 'unknown_view')))
-    assert_equals(response.status_code, 404)
+    assert response.status_code == 404
 
 
 @temp_scenario(MultiViewXBlock, "multiview")
@@ -66,15 +66,15 @@ def test_multiple_views():
 
     # The default view is student_view
     response = client.get("/view/multiview/")
-    assert_in("This is student view!", response.content.decode('utf-8'))
+    assert "This is student view!" in response.content.decode('utf-8')
 
     # We can ask for student_view directly
     response = client.get("/view/multiview/student_view/")
-    assert_in("This is student view!", response.content.decode('utf-8'))
+    assert "This is student view!"in response.content.decode('utf-8')
 
     # We can also ask for another view.
     response = client.get("/view/multiview/another_view/")
-    assert_in("This is another view!", response.content.decode('utf-8'))
+    assert "This is another view!"in response.content.decode('utf-8')
 
 
 class XBlockWithHandlerAndStudentState(XBlock):
@@ -105,21 +105,21 @@ def test_xblock_with_handler():
     response_content = response.content.decode('utf-8')
 
     expected = u"The data: %r." % u"def"
-    assert_true(expected in response_content)
+    assert(expected in response_content)
 
     parsed = response_content.split(':::')
-    assert_equals(len(parsed), 3)
+    assert len(parsed) == 3
     handler_url = parsed[1]
 
     # Now change the data.
     response = client.post(handler_url, "{}", "text/json")
     the_data = json.loads(response.content)['the_data']
-    assert_equals(the_data, "defx")
+    assert the_data == "defx"
 
     # Change it again.
     response = client.post(handler_url, "{}", "text/json")
     the_data = json.loads(response.content)['the_data']
-    assert_equals(the_data, "defxx")
+    assert the_data == "defxx"
 
 
 @temp_scenario(XBlock)
@@ -142,7 +142,7 @@ def test_xblock_without_handler():
     # The default XBlock implementation doesn't provide
     # a handler, so this call should raise an exception
     # (from xblock.runtime.Runtime.handle)
-    with assert_raises(NoSuchHandlerError):
+    with pytest.raises(NoSuchHandlerError):
         client.post(handler_url, '{}', 'text/json')
 
 
@@ -154,7 +154,7 @@ def test_xblock_invalid_handler_url():
 
     handler_url = "/handler/obviously/a/fake/handler"
     result = client.post(handler_url, '{}', 'text/json')
-    assert_equals(result.status_code, 404)
+    assert result.status_code == 404
 
 
 class XBlockWithHandlers(XBlock):
@@ -185,11 +185,11 @@ class XBlockWithHandlers(XBlock):
     def try_bad_handler_urls(self, context=None):       # pylint: disable=W0613
         """Force some assertions for the wrong kinds of handlers."""
         # A completely non-existing function name.
-        with assert_raises_regexp(ValueError, "function name"):
+        with pytest.raises(ValueError, match="function name"):
             self.runtime.handler_url(self, "this_doesnt_exist")
 
         # An existing function, but it isn't a handler.
-        with assert_raises_regexp(ValueError, "handler name"):
+        with pytest.raises(ValueError, match="handler name"):
             self.runtime.handler_url(self, "try_bad_handler_urls")
 
         return Fragment(u"Everything is Fine!")
@@ -197,7 +197,7 @@ class XBlockWithHandlers(XBlock):
     @XBlock.handler
     def send_it_back(self, request, suffix=''):
         """Just return the data we got."""
-        assert_equals(self.scope_ids.user_id, "student_1")
+        assert self.scope_ids.user_id == "student_1"
         response_json = json.dumps({
             'suffix': suffix,
             'a': request.GET.get('a', "no-a"),
@@ -208,7 +208,7 @@ class XBlockWithHandlers(XBlock):
     @XBlock.handler
     def send_it_back_public(self, request, suffix=''):
         """Just return the data we got."""
-        assert_equals(self.scope_ids.user_id, "none")
+        assert self.scope_ids.user_id == "none"
         response_json = json.dumps({
             'suffix': suffix,
             'a': request.GET.get('a', "no-a"),
@@ -225,7 +225,7 @@ def test_xblock_with_handlers():
     # The view sends a list of URLs to try.
     response = client.get("/view/with-handlers/")
     parsed = response.content.decode('utf-8').split(':::')
-    assert_equals(len(parsed), 3)
+    assert len(parsed) == 3
     urls = json.loads(parsed[1])
 
     # These have to correspond to the urls in XBlockWithHandlers.student_view above.
@@ -245,9 +245,9 @@ def test_xblock_with_handlers():
     for url, expected in zip(urls, expecteds):
         print(url)   # so we can see which one failed, if any.
         response = client.get(url)
-        assert_equals(response.status_code, 200)
+        assert response.status_code == 200
         actual = json.loads(response.content)
-        assert_equals(actual, expected)
+        assert actual == expected
 
 
 @temp_scenario(XBlockWithHandlers, 'with-handlers')
@@ -255,8 +255,8 @@ def test_bad_handler_urls():
     client = Client()
 
     response = client.get("/view/with-handlers/try_bad_handler_urls/")
-    assert_equals(response.status_code, 200)
-    assert_in("Everything is Fine!", response.content.decode('utf-8'))
+    assert response.status_code == 200
+    assert "Everything is Fine!" in response.content.decode('utf-8')
 
 
 class XBlockWithoutStudentView(XBlock):
@@ -273,7 +273,7 @@ def test_xblock_no_student_view():
     # indicates there is no view available.
     client = Client()
     response = client.get("/view/xblockwithoutstudentview/")
-    assert_true('No such view' in response.content.decode('utf-8'))
+    assert('No such view' in response.content.decode('utf-8'))
 
 
 def test_local_resources():
@@ -281,8 +281,8 @@ def test_local_resources():
 
     # The Equality block has local resources
     result = client.get('/resource/equality_demo/public/images/correct-icon.png')
-    assert_equals(result.status_code, 200)
-    assert_equals(result['Content-Type'], 'image/png')
+    assert result.status_code == 200
+    assert result['Content-Type'] == 'image/png'
 
     # The Equality block defends against malicious resource URIs
     # This test has two possible ways of passing
@@ -296,7 +296,7 @@ def test_local_resources():
     # support both prod and dev configurations.
     try:
         result = client.get('/resource/equality_demo/core.py')
-        assert_equals(result.status_code, 404)
+        assert result.status_code == 404
     except DisallowedFileError:
         pass
 
@@ -332,22 +332,22 @@ class XBlockWithContextTracking(XBlock):
 @temp_scenario(XBlockWithContextTracking, 'context_tracking')
 def test_activate_id():
     client = Client()
-    assert_equals(XBlockWithContextTracking.registered_contexts, [])  # precondition check
+    assert XBlockWithContextTracking.registered_contexts == []  # precondition check
     client.get("/view/context_tracking/")
-    assert_equals(XBlockWithContextTracking.registered_contexts, [{'activate_block_id': None}])
+    assert XBlockWithContextTracking.registered_contexts == [{'activate_block_id': None}]
 
     client.get("/view/context_tracking/?activate_block_id=123")
-    assert_equals(XBlockWithContextTracking.registered_contexts, [
+    assert XBlockWithContextTracking.registered_contexts == [
         {'activate_block_id': None}, {'activate_block_id': '123'}
-    ])
+    ]
 
     XBlockWithContextTracking.clear_contexts()
     client.get("/view/context_tracking/?activate_block_id=456")
-    assert_equals(XBlockWithContextTracking.registered_contexts, [{'activate_block_id': '456'}])
+    assert XBlockWithContextTracking.registered_contexts == [{'activate_block_id': '456'}]
 
 
 def test_user_list():
     client = Client()
     result = client.get("/userlist/")
-    assert_equals(result.status_code, 200)
-    assert_equals(result.content.decode('utf-8'), "[]")
+    assert result.status_code == 200
+    assert result.content.decode('utf-8') == "[]"

--- a/workbench/test/test_views.py
+++ b/workbench/test/test_views.py
@@ -105,7 +105,7 @@ def test_xblock_with_handler():
     response_content = response.content.decode('utf-8')
 
     expected = u"The data: %r." % u"def"
-    assert(expected in response_content)
+    assert expected in response_content
 
     parsed = response_content.split(':::')
     assert len(parsed) == 3
@@ -273,7 +273,7 @@ def test_xblock_no_student_view():
     # indicates there is no view available.
     client = Client()
     response = client.get("/view/xblockwithoutstudentview/")
-    assert('No such view' in response.content.decode('utf-8'))
+    assert 'No such view' in response.content.decode('utf-8')
 
 
 def test_local_resources():


### PR DESCRIPTION
One of the tests cases failing in edx-platform due the this [failure](https://openedx.atlassian.net/browse/BOM-415) in [xblock-drag-and-drop-v2](https://github.com/edx-solutions/xblock-drag-and-drop-v2). I have modernize that repo. But its tests are still failing in python3.5 because of xblock-sdk is using acid-block repo with very old commit.  acid-block using unicode method which is root cause of the failure.

xblock-drag-and-drop-v2 is using xblock-sdk and it is using acid-block. We have to update the acid-block version in this repo now.

[BOM-470](https://openedx.atlassian.net/browse/BOM-470)