### PR TITLE
Update requirements to fix pip-compile issues

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,3 +10,5 @@
 
 # These packages are backports which can only be installed on Python 2.7
 futures ; python_version == "2.7"
+astroid<2.0
+edx-lint<1.4.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -18,3 +18,4 @@ edx-lint<1.4.0
 more-itertools<=5.0.0
 pillow<=6.2.2
 pytest<=4.6.9
+pydocstyle<4.0.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -10,5 +10,11 @@
 
 # These packages are backports which can only be installed on Python 2.7
 futures ; python_version == "2.7"
+
+# These packages still support Python 2.7, and are required for compatibility with Django 1.11
+# See https://github.com/edx/xblock-sdk/pull/169
 astroid<2.0
 edx-lint<1.4.0
+more-itertools<=5.0.0
+pillow<=6.2.2
+pytest<=4.6.9

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,7 +6,7 @@ boto==2.39.0
 cookiecutter==0.9.0
 Django>=1.11
 django-pyfs==2.0
-fs-s3fs==0.1.5
+fs-s3fs==0.1.8
 lxml==3.8.0
 lazy==1.1
 requests==2.22.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,9 +6,9 @@
 #
 appdirs==1.4.3            # via fs
 binaryornot==0.4.4        # via cookiecutter
-boto3==1.12.5             # via fs-s3fs
+boto3==1.12.8             # via fs-s3fs
 boto==2.39.0
-botocore==1.15.5          # via boto3, s3transfer
+botocore==1.15.8          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via binaryornot, requests
 cookiecutter==0.9.0
@@ -19,7 +19,7 @@ fs-s3fs==0.1.8
 fs==2.0.27                # via django-pyfs, fs-s3fs, xblock
 idna==2.8                 # via requests
 jinja2==2.11.1            # via cookiecutter
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.5           # via boto3, botocore
 lazy==1.1
 lxml==3.8.0
 markupsafe==1.1.1         # via jinja2, xblock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,43 +5,38 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via fs
-backports.os==0.1.1       # via fs
 binaryornot==0.4.4        # via cookiecutter
-boto3==1.4.8              # via fs-s3fs
+boto3==1.12.5             # via fs-s3fs
 boto==2.39.0
-botocore==1.8.50          # via boto3, s3transfer
+botocore==1.15.5          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via binaryornot, requests
 cookiecutter==0.9.0
 django-pyfs==2.0
-django==1.11.26
+django==2.2.10
 docutils==0.15.2          # via botocore
-enum34==1.1.6             # via fs
-fs-s3fs==0.1.5
+fs-s3fs==0.1.8
 fs==2.0.27                # via django-pyfs, fs-s3fs, xblock
-funcsigs==1.0.2           # via mock
-future==0.18.2            # via backports.os
-futures==3.3.0 ; python_version == "2.7"  # via s3transfer
 idna==2.8                 # via requests
-jinja2==2.10.3            # via cookiecutter
+jinja2==2.11.1            # via cookiecutter
 jmespath==0.9.4           # via boto3, botocore
 lazy==1.1
 lxml==3.8.0
 markupsafe==1.1.1         # via jinja2, xblock
-mock==3.0.5               # via cookiecutter
 pypng==0.0.20
 python-dateutil==2.8.1    # via botocore, xblock
 pytz==2019.3              # via django, fs, xblock
-pyyaml==5.2               # via cookiecutter, xblock
+pyyaml==5.3               # via cookiecutter, xblock
 requests==2.22.0
-s3transfer==0.1.13        # via boto3
+s3transfer==0.3.3         # via boto3
 simplejson==3.17.0
-six==1.10.0               # via django-pyfs, fs, fs-s3fs, mock, python-dateutil, xblock
+six==1.14.0               # via django-pyfs, fs, fs-s3fs, python-dateutil, xblock
+sqlparse==0.3.0           # via django
 typing==3.7.4.1           # via fs
-urllib3==1.25.7           # via requests
+urllib3==1.25.8           # via botocore, requests
 web-fragments==0.3.1
-webob==1.8.5
+webob==1.8.6
 xblock==1.2.9
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==42.0.2        # via fs, lazy
+# setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,9 +6,9 @@
 #
 appdirs==1.4.3            # via fs
 binaryornot==0.4.4        # via cookiecutter
-boto3==1.12.8             # via fs-s3fs
+boto3==1.12.9             # via fs-s3fs
 boto==2.39.0
-botocore==1.15.8          # via boto3, s3transfer
+botocore==1.15.9          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via binaryornot, requests
 cookiecutter==0.9.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,13 +6,13 @@
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
 appdirs==1.4.3            # via fs, virtualenv
-astroid==2.3.3            # via pylint, pylint-celery
+astroid==1.5.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 binaryornot==0.4.4        # via cookiecutter
 bok_choy==0.7.1
-boto3==1.12.5             # via fs-s3fs
+boto3==1.12.8             # via fs-s3fs
 boto==2.39.0
-botocore==1.15.5          # via boto3, s3transfer
+botocore==1.15.8          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via binaryornot, requests
 click-log==0.3.2          # via edx-lint
@@ -24,7 +24,7 @@ distlib==0.3.0            # via virtualenv
 django-pyfs==2.0
 django==2.2.10
 docutils==0.15.2          # via botocore
-edx-lint==1.4.1
+edx-lint==1.3.1
 filelock==3.0.12          # via tox, virtualenv
 fs-s3fs==0.1.8
 fs==2.0.27                # via django-pyfs, fs-s3fs, xblock
@@ -33,7 +33,7 @@ importlib-metadata==1.5.0  # via pluggy, pytest, tox, virtualenv
 importlib-resources==1.0.2  # via virtualenv
 isort==4.3.21
 jinja2==2.11.1            # via cookiecutter
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.5           # via boto3, botocore
 lazy-object-proxy==1.4.3  # via astroid
 lazy==1.1
 lxml==3.8.0
@@ -52,9 +52,9 @@ py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0
 pydocstyle==5.0.2
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.6          # via packaging
 pypng==0.0.20
 pytest-cov==2.8.1
@@ -74,14 +74,13 @@ sqlparse==0.3.0           # via django
 toml==0.10.0              # via tox
 tox-battery==0.5.2
 tox==3.14.5
-typed-ast==1.4.1          # via astroid
 typing==3.7.4.1           # via fs
 urllib3==1.25.8           # via botocore, requests
-virtualenv==20.0.5        # via tox
+virtualenv==20.0.7        # via tox
 wcwidth==0.1.8            # via pytest
 web-fragments==0.3.1
 webob==1.8.6
-wrapt==1.11.2             # via astroid
+wrapt==1.12.0             # via astroid
 xblock==1.2.9
 zipp==1.2.0               # via importlib-metadata
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,9 +11,9 @@ atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 binaryornot==0.4.4        # via cookiecutter
 bok_choy==0.7.1
-boto3==1.12.8             # via fs-s3fs
+boto3==1.12.9             # via fs-s3fs
 boto==2.39.0
-botocore==1.15.8          # via boto3, s3transfer
+botocore==1.15.9          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via binaryornot, requests
 click-log==0.3.2          # via edx-lint
@@ -51,7 +51,7 @@ pillow==6.2.2             # via needle
 pluggy==0.13.1            # via pytest, tox
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0
-pydocstyle==5.0.2
+pydocstyle==3.0.0
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,92 +5,85 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
-appdirs==1.4.3            # via fs
-astroid==1.6.6            # via pylint, pylint-celery
-atomicwrites==1.3.0       # via pytest
+appdirs==1.4.3            # via fs, virtualenv
+astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
-backports.os==0.1.1       # via fs
 binaryornot==0.4.4        # via cookiecutter
 bok_choy==0.7.1
-boto3==1.4.8              # via fs-s3fs
+boto3==1.12.5             # via fs-s3fs
 boto==2.39.0
-botocore==1.8.50          # via boto3, s3transfer
+botocore==1.15.5          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via binaryornot, requests
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
-configparser==4.0.2       # via importlib-metadata, pydocstyle, pylint
-contextlib2==0.6.0.post1  # via importlib-metadata
 cookiecutter==0.9.0
-coverage==4.5.4
+coverage==5.0.3
 ddt==1.2.2
+distlib==0.3.0            # via virtualenv
 django-pyfs==2.0
-django==1.11.26
+django==2.2.10
 docutils==0.15.2          # via botocore
 edx-lint==1.4.1
-enum34==1.1.6             # via astroid, fs
-filelock==3.0.12          # via tox
-fs-s3fs==0.1.5
+filelock==3.0.12          # via tox, virtualenv
+fs-s3fs==0.1.8
 fs==2.0.27                # via django-pyfs, fs-s3fs, xblock
-funcsigs==1.0.2           # via mock, pytest
-future==0.18.2            # via backports.os
-futures==3.3.0 ; python_version == "2.7"  # via isort, s3transfer
 idna==2.8                 # via requests
-importlib-metadata==1.3.0  # via pluggy, pytest, tox
+importlib-metadata==1.5.0  # via pluggy, pytest, tox, virtualenv
+importlib-resources==1.0.2  # via virtualenv
 isort==4.3.21
-jinja2==2.10.3            # via cookiecutter
+jinja2==2.11.1            # via cookiecutter
 jmespath==0.9.4           # via boto3, botocore
 lazy-object-proxy==1.4.3  # via astroid
 lazy==1.1
 lxml==3.8.0
-mako==1.1.0
+mako==1.1.1
 markupsafe==1.1.1         # via jinja2, mako, xblock
 mccabe==0.6.1             # via pylint
 mock==3.0.5
-more-itertools==5.0.0     # via pytest, zipp
+more-itertools==8.2.0     # via pytest
 needle==0.5.0             # via bok-choy
 nose==1.3.7               # via needle
-packaging==19.2           # via pytest, tox
-pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
-pillow==6.2.1             # via needle
+packaging==20.1           # via pytest, tox
+pathlib2==2.3.5           # via pytest
+pillow==7.0.0             # via needle
 pluggy==0.13.1            # via pytest, tox
-py==1.8.0                 # via pytest, tox
+py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0
-pydocstyle==3.0.0
+pydocstyle==5.0.2
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.11.1     # via edx-lint
+pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pyparsing==2.4.5          # via packaging
+pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pyparsing==2.4.6          # via packaging
 pypng==0.0.20
 pytest-cov==2.8.1
-pytest-django==3.7.0
+pytest-django==3.8.0
 pytest-rerunfailures==8.0
-pytest==4.6.7             # via pytest-cov, pytest-django, pytest-rerunfailures
+pytest==5.3.5             # via pytest-cov, pytest-django, pytest-rerunfailures
 python-dateutil==2.8.1    # via botocore, xblock
 pytz==2019.3              # via django, fs, xblock
-pyyaml==5.2               # via cookiecutter, xblock
+pyyaml==5.3               # via cookiecutter, xblock
 requests==2.22.0
-s3transfer==0.1.13        # via boto3
-scandir==1.10.0           # via pathlib2
+s3transfer==0.3.3         # via boto3
 selenium==3.4.1
 simplejson==3.17.0
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.10.0
+six==1.14.0
 snowballstemmer==2.0.0    # via pydocstyle
+sqlparse==0.3.0           # via django
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.2
+tox-battery==0.5.2
+tox==3.14.5
+typed-ast==1.4.1          # via astroid
 typing==3.7.4.1           # via fs
-urllib3==1.25.7           # via requests
-virtualenv==16.7.8        # via tox
-wcwidth==0.1.7            # via pytest
+urllib3==1.25.8           # via botocore, requests
+virtualenv==20.0.5        # via tox
+wcwidth==0.1.8            # via pytest
 web-fragments==0.3.1
-webob==1.8.5
+webob==1.8.6
 wrapt==1.11.2             # via astroid
 xblock==1.2.9
-zipp==0.6.0               # via importlib-metadata
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==42.0.2        # via fs, lazy, pytest-rerunfailures
+# setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,6 +7,7 @@
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
 appdirs==1.4.3            # via fs, virtualenv
 astroid==1.5.3            # via pylint, pylint-celery
+atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 binaryornot==0.4.4        # via cookiecutter
 bok_choy==0.7.1
@@ -41,12 +42,12 @@ mako==1.1.1
 markupsafe==1.1.1         # via jinja2, mako, xblock
 mccabe==0.6.1             # via pylint
 mock==3.0.5
-more-itertools==8.2.0     # via pytest
+more-itertools==5.0.0     # via pytest
 needle==0.5.0             # via bok-choy
 nose==1.3.7               # via needle
 packaging==20.1           # via pytest, tox
 pathlib2==2.3.5           # via pytest
-pillow==7.0.0             # via needle
+pillow==6.2.2             # via needle
 pluggy==0.13.1            # via pytest, tox
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0
@@ -60,7 +61,7 @@ pypng==0.0.20
 pytest-cov==2.8.1
 pytest-django==3.8.0
 pytest-rerunfailures==8.0
-pytest==5.3.5             # via pytest-cov, pytest-django, pytest-rerunfailures
+pytest==4.6.9             # via pytest-cov, pytest-django, pytest-rerunfailures
 python-dateutil==2.8.1    # via botocore, xblock
 pytz==2019.3              # via django, fs, xblock
 pyyaml==5.3               # via cookiecutter, xblock

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -6,4 +6,4 @@ edx-lint                  # edX pylint rules and plugins
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
-six==1.10.0               # Prevents a version conflict between this file and test.txt
+six==1.14.0               # Prevents a version conflict between this file and test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,7 +12,7 @@ isort==4.3.21
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 pycodestyle==2.5.0
-pydocstyle==5.0.2
+pydocstyle==3.0.0
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,24 +4,20 @@
 #
 #    make upgrade
 #
-astroid==1.6.6            # via pylint, pylint-celery
-backports.functools-lru-cache==1.6.1  # via astroid, isort, pylint
+astroid==2.3.3            # via pylint, pylint-celery
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
-configparser==4.0.2       # via pydocstyle, pylint
 edx-lint==1.4.1
-enum34==1.1.6             # via astroid
-futures==3.3.0 ; python_version == "2.7"  # via isort
 isort==4.3.21
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 pycodestyle==2.5.0
-pydocstyle==3.0.0
+pydocstyle==5.0.2
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.11.1     # via edx-lint
+pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.10.0
+pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+six==1.14.0
 snowballstemmer==2.0.0    # via pydocstyle
+typed-ast==1.4.1          # via astroid
 wrapt==1.11.2             # via astroid

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,20 +4,19 @@
 #
 #    make upgrade
 #
-astroid==2.3.3            # via pylint, pylint-celery
+astroid==1.5.3            # via pylint, pylint-celery
 click-log==0.3.2          # via edx-lint
 click==7.0                # via click-log, edx-lint
-edx-lint==1.4.1
+edx-lint==1.3.1
 isort==4.3.21
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 pycodestyle==2.5.0
 pydocstyle==5.0.2
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 six==1.14.0
 snowballstemmer==2.0.0    # via pydocstyle
-typed-ast==1.4.1          # via astroid
-wrapt==1.11.2             # via astroid
+wrapt==1.12.0             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,6 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
 appdirs==1.4.3            # via fs, virtualenv
+atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 binaryornot==0.4.4        # via cookiecutter
 bok_choy==0.7.1
@@ -33,12 +34,12 @@ lxml==3.8.0
 mako==1.1.1
 markupsafe==1.1.1         # via jinja2, mako, xblock
 mock==3.0.5
-more-itertools==8.2.0     # via pytest
+more-itertools==5.0.0     # via pytest
 needle==0.5.0             # via bok-choy
 nose==1.3.7               # via needle
 packaging==20.1           # via pytest, tox
 pathlib2==2.3.5           # via pytest
-pillow==7.0.0             # via needle
+pillow==6.2.2             # via needle
 pluggy==0.13.1            # via pytest, tox
 py==1.8.1                 # via pytest, tox
 pyparsing==2.4.6          # via packaging
@@ -46,7 +47,7 @@ pypng==0.0.20
 pytest-cov==2.8.1
 pytest-django==3.8.0
 pytest-rerunfailures==8.0
-pytest==5.3.5             # via pytest-cov, pytest-django, pytest-rerunfailures
+pytest==4.6.9             # via pytest-cov, pytest-django, pytest-rerunfailures
 python-dateutil==2.8.1    # via botocore, xblock
 pytz==2019.3              # via django, fs, xblock
 pyyaml==5.3               # via cookiecutter, xblock
@@ -54,7 +55,7 @@ requests==2.22.0
 s3transfer==0.3.3         # via boto3
 selenium==3.4.1
 simplejson==3.17.0
-six==1.14.0               # via bok-choy, django-pyfs, fs, fs-s3fs, mock, packaging, pathlib2, python-dateutil, tox, virtualenv, xblock
+six==1.14.0               # via bok-choy, django-pyfs, fs, fs-s3fs, mock, more-itertools, packaging, pathlib2, pytest, python-dateutil, tox, virtualenv, xblock
 sqlparse==0.3.0           # via django
 toml==0.10.0              # via tox
 tox-battery==0.5.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,9 +9,9 @@ appdirs==1.4.3            # via fs, virtualenv
 attrs==19.3.0             # via pytest
 binaryornot==0.4.4        # via cookiecutter
 bok_choy==0.7.1
-boto3==1.12.5             # via fs-s3fs
+boto3==1.12.8             # via fs-s3fs
 boto==2.39.0
-botocore==1.15.5          # via boto3, s3transfer
+botocore==1.15.8          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via binaryornot, requests
 cookiecutter==0.9.0
@@ -27,7 +27,7 @@ idna==2.8                 # via requests
 importlib-metadata==1.5.0  # via pluggy, pytest, tox, virtualenv
 importlib-resources==1.0.2  # via virtualenv
 jinja2==2.11.1            # via cookiecutter
-jmespath==0.9.4           # via boto3, botocore
+jmespath==0.9.5           # via boto3, botocore
 lazy==1.1
 lxml==3.8.0
 mako==1.1.1
@@ -61,7 +61,7 @@ tox-battery==0.5.2
 tox==3.14.5
 typing==3.7.4.1           # via fs
 urllib3==1.25.8           # via botocore, requests
-virtualenv==20.0.5        # via tox
+virtualenv==20.0.7        # via tox
 wcwidth==0.1.8            # via pytest
 web-fragments==0.3.1
 webob==1.8.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,9 +10,9 @@ atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
 binaryornot==0.4.4        # via cookiecutter
 bok_choy==0.7.1
-boto3==1.12.8             # via fs-s3fs
+boto3==1.12.9             # via fs-s3fs
 boto==2.39.0
-botocore==1.15.8          # via boto3, s3transfer
+botocore==1.15.9          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via binaryornot, requests
 cookiecutter==0.9.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,74 +5,68 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
-appdirs==1.4.3            # via fs
-atomicwrites==1.3.0       # via pytest
+appdirs==1.4.3            # via fs, virtualenv
 attrs==19.3.0             # via pytest
-backports.os==0.1.1       # via fs
 binaryornot==0.4.4        # via cookiecutter
 bok_choy==0.7.1
-boto3==1.4.8              # via fs-s3fs
+boto3==1.12.5             # via fs-s3fs
 boto==2.39.0
-botocore==1.8.50          # via boto3, s3transfer
+botocore==1.15.5          # via boto3, s3transfer
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via binaryornot, requests
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
 cookiecutter==0.9.0
-coverage==4.5.4
+coverage==5.0.3
 ddt==1.2.2
+distlib==0.3.0            # via virtualenv
 django-pyfs==2.0
 docutils==0.15.2          # via botocore
-enum34==1.1.6             # via fs
-filelock==3.0.12          # via tox
-fs-s3fs==0.1.5
+filelock==3.0.12          # via tox, virtualenv
+fs-s3fs==0.1.8
 fs==2.0.27                # via django-pyfs, fs-s3fs, xblock
-funcsigs==1.0.2           # via mock, pytest
-future==0.18.2            # via backports.os
-futures==3.3.0 ; python_version == "2.7"  # via s3transfer
 idna==2.8                 # via requests
-importlib-metadata==1.3.0  # via pluggy, pytest, tox
-jinja2==2.10.3            # via cookiecutter
+importlib-metadata==1.5.0  # via pluggy, pytest, tox, virtualenv
+importlib-resources==1.0.2  # via virtualenv
+jinja2==2.11.1            # via cookiecutter
 jmespath==0.9.4           # via boto3, botocore
 lazy==1.1
 lxml==3.8.0
-mako==1.1.0
+mako==1.1.1
 markupsafe==1.1.1         # via jinja2, mako, xblock
 mock==3.0.5
-more-itertools==5.0.0     # via pytest, zipp
+more-itertools==8.2.0     # via pytest
 needle==0.5.0             # via bok-choy
 nose==1.3.7               # via needle
-packaging==19.2           # via pytest, tox
-pathlib2==2.3.5           # via importlib-metadata, pytest, pytest-django
-pillow==6.2.1             # via needle
+packaging==20.1           # via pytest, tox
+pathlib2==2.3.5           # via pytest
+pillow==7.0.0             # via needle
 pluggy==0.13.1            # via pytest, tox
-py==1.8.0                 # via pytest, tox
-pyparsing==2.4.5          # via packaging
+py==1.8.1                 # via pytest, tox
+pyparsing==2.4.6          # via packaging
 pypng==0.0.20
 pytest-cov==2.8.1
-pytest-django==3.7.0
+pytest-django==3.8.0
 pytest-rerunfailures==8.0
-pytest==4.6.7             # via pytest-cov, pytest-django, pytest-rerunfailures
+pytest==5.3.5             # via pytest-cov, pytest-django, pytest-rerunfailures
 python-dateutil==2.8.1    # via botocore, xblock
 pytz==2019.3              # via django, fs, xblock
-pyyaml==5.2               # via cookiecutter, xblock
+pyyaml==5.3               # via cookiecutter, xblock
 requests==2.22.0
-s3transfer==0.1.13        # via boto3
-scandir==1.10.0           # via pathlib2
+s3transfer==0.3.3         # via boto3
 selenium==3.4.1
 simplejson==3.17.0
-six==1.10.0               # via bok-choy, django-pyfs, fs, fs-s3fs, mock, more-itertools, packaging, pathlib2, pytest, python-dateutil, tox, xblock
+six==1.14.0               # via bok-choy, django-pyfs, fs, fs-s3fs, mock, packaging, pathlib2, python-dateutil, tox, virtualenv, xblock
+sqlparse==0.3.0           # via django
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.2
+tox-battery==0.5.2
+tox==3.14.5
 typing==3.7.4.1           # via fs
-urllib3==1.25.7           # via requests
-virtualenv==16.7.8        # via tox
-wcwidth==0.1.7            # via pytest
+urllib3==1.25.8           # via botocore, requests
+virtualenv==20.0.5        # via tox
+wcwidth==0.1.8            # via pytest
 web-fragments==0.3.1
-webob==1.8.5
+webob==1.8.6
 xblock==1.2.9
-zipp==0.6.0               # via importlib-metadata
+zipp==1.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==42.0.2        # via fs, lazy, pytest-rerunfailures
+# setuptools

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,7 +7,7 @@
 appdirs==1.4.3            # via virtualenv
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.15
+codecov==2.0.16
 coverage==5.0.3           # via codecov
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
@@ -24,5 +24,5 @@ toml==0.10.0              # via tox
 tox-battery==0.5.2
 tox==3.14.5
 urllib3==1.25.8           # via requests
-virtualenv==20.0.5        # via tox
+virtualenv==20.0.7        # via tox
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,27 +4,25 @@
 #
 #    make upgrade
 #
+appdirs==1.4.3            # via virtualenv
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
-coverage==4.5.4           # via codecov
-filelock==3.0.12          # via tox
-idna==2.8                 # via requests
-importlib-metadata==1.3.0  # via pluggy, tox
-more-itertools==5.0.0     # via zipp
-packaging==19.2           # via tox
-pathlib2==2.3.5           # via importlib-metadata
+coverage==5.0.3           # via codecov
+distlib==0.3.0            # via virtualenv
+filelock==3.0.12          # via tox, virtualenv
+idna==2.9                 # via requests
+importlib-metadata==1.5.0  # via pluggy, tox, virtualenv
+importlib-resources==1.0.2  # via virtualenv
+packaging==20.1           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.0                 # via tox
-pyparsing==2.4.5          # via packaging
-requests==2.22.0          # via codecov
-scandir==1.10.0           # via pathlib2
-six==1.13.0               # via more-itertools, packaging, pathlib2, tox
+py==1.8.1                 # via tox
+pyparsing==2.4.6          # via packaging
+requests==2.23.0          # via codecov
+six==1.14.0               # via packaging, tox, virtualenv
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.2
-urllib3==1.25.7           # via requests
-virtualenv==16.7.8        # via tox
-zipp==0.6.0               # via importlib-metadata
+tox-battery==0.5.2
+tox==3.14.5
+urllib3==1.25.8           # via requests
+virtualenv==20.0.5        # via tox
+zipp==1.2.0               # via importlib-metadata

--- a/sample_xblocks/basic/problem.py
+++ b/sample_xblocks/basic/problem.py
@@ -332,7 +332,7 @@ class CheckerBlock(XBlock):
         """
         # Introspect the .check() method, and collect arguments it expects.
         if hasattr(inspect, 'getfullargspec'):
-            # pylint: disable=no-member, useless-suppression
+            # pylint: disable=no-member, useless-suppression, deprecated-method
             argspec = inspect.getfullargspec(self.check)
         else:
             argspec = inspect.getargspec(self.check)  # pylint: disable=deprecated-method


### PR DESCRIPTION
When updating requirements for https://github.com/open-craft/problem-builder/pull/262, we were unable to get pip-compile to resolve dependencies, as the xblock inherits requirements from xblock-sdk, and there were unresolvable dependencies.

This updates 2 requirements to allow pip-upgrade to work in both xblock-sdk and problem-builder requirements.

**Reviewers**
- [ ] (@lgp171188)
- [ ] edX reviewer[s] TBD