### PR TITLE
Removed all usages of package six

### DIFF
--- a/bin/workbench-make-xblock
+++ b/bin/workbench-make-xblock
@@ -4,10 +4,10 @@ Use cookiecutter to create a new XBlock project.
 """
 from __future__ import print_function
 
-from builtins import input
 import os
 import re
 import textwrap
+from builtins import input
 
 from cookiecutter.main import cookiecutter
 

--- a/manage.py
+++ b/manage.py
@@ -1,8 +1,8 @@
 """Manage.py file for XBlock"""
-import django
-
 import os
 import sys
+
+import django
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "workbench.settings")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,41 +5,41 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via fs
-arrow==0.15.6             # via jinja2-time
+arrow==0.15.7             # via jinja2-time
 binaryornot==0.4.4        # via cookiecutter
-boto3==1.13.23            # via fs-s3fs
+boto3==1.14.26            # via fs-s3fs
 boto==2.49.0              # via -r requirements/base.in
-botocore==1.16.23         # via boto3, s3transfer
-certifi==2020.4.5.1       # via requests
+botocore==1.17.26         # via boto3, s3transfer
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via binaryornot, requests
 click==7.1.2              # via cookiecutter
 cookiecutter==1.7.2       # via -r requirements/base.in
-django-pyfs==2.1          # via -r requirements/base.in
-django==2.2.13            # via -r requirements/base.in, django-pyfs
+django-pyfs==2.2          # via -r requirements/base.in
+django==2.2.14            # via -r requirements/base.in, django-pyfs
 docutils==0.15.2          # via botocore
 fs-s3fs==1.1.1            # via -r requirements/base.in, django-pyfs
 fs==2.4.11                # via django-pyfs, fs-s3fs, xblock
-idna==2.9                 # via requests
+idna==2.10                # via requests
 jinja2-time==0.2.0        # via cookiecutter
 jinja2==2.11.2            # via cookiecutter, jinja2-time
 jmespath==0.10.0          # via boto3, botocore
 lazy==1.4                 # via -r requirements/base.in
-lxml==4.5.1               # via -r requirements/base.in, xblock
+lxml==4.5.2               # via -r requirements/base.in, xblock
 markupsafe==1.1.1         # via cookiecutter, jinja2, xblock
 poyo==0.5.0               # via cookiecutter
 pypng==0.0.20             # via -r requirements/base.in
 python-dateutil==2.8.1    # via arrow, botocore, xblock
-python-slugify==4.0.0     # via cookiecutter
+python-slugify==4.0.1     # via cookiecutter
 pytz==2020.1              # via django, fs, xblock
 pyyaml==5.3.1             # via xblock
-requests==2.23.0          # via -r requirements/base.in, cookiecutter
+requests==2.24.0          # via -r requirements/base.in, cookiecutter
 s3transfer==0.3.3         # via boto3
-simplejson==3.17.0        # via -r requirements/base.in
-six==1.15.0               # via cookiecutter, django-pyfs, fs, fs-s3fs, python-dateutil, xblock
+simplejson==3.17.2        # via -r requirements/base.in
+six==1.15.0               # via cookiecutter, fs, fs-s3fs, python-dateutil, xblock
 sqlparse==0.3.1           # via django
 text-unidecode==1.3       # via python-slugify
-typing==3.7.4.1           # via fs
-urllib3==1.25.9           # via botocore, requests
+typing==3.7.4.3           # via fs
+urllib3==1.25.10          # via botocore, requests
 web-fragments==0.3.2      # via -r requirements/base.in, xblock
 webob==1.8.6              # via -r requirements/base.in, xblock
 xblock==1.3.1             # via -r requirements/base.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,84 +6,84 @@
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock  # via -r requirements/test.in, -r requirements/test.txt
 appdirs==1.4.4            # via -r requirements/test.txt, fs, virtualenv
-arrow==0.15.6             # via -r requirements/test.txt, jinja2-time
+arrow==0.15.7             # via -r requirements/test.txt, jinja2-time
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 binaryornot==0.4.4        # via -r requirements/test.txt, cookiecutter
 bok_choy==0.7.1           # via -r requirements/test.in, -r requirements/test.txt
-boto3==1.13.23            # via -r requirements/test.txt, fs-s3fs
+boto3==1.14.26            # via -r requirements/test.txt, fs-s3fs
 boto==2.49.0              # via -r requirements/base.in, -r requirements/test.txt
-botocore==1.16.23         # via -r requirements/test.txt, boto3, s3transfer
-certifi==2020.4.5.1       # via -r requirements/test.txt, requests
+botocore==1.17.26         # via -r requirements/test.txt, boto3, s3transfer
+certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, binaryornot, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, cookiecutter, edx-lint
 cookiecutter==1.7.2       # via -r requirements/base.in, -r requirements/test.txt
-coverage==5.1             # via -r requirements/test.in, -r requirements/test.txt, pytest-cov
+coverage==5.2             # via -r requirements/test.in, -r requirements/test.txt, pytest-cov
 ddt==1.4.1                # via -r requirements/test.in, -r requirements/test.txt
-distlib==0.3.0            # via -r requirements/test.txt, virtualenv
-django-pyfs==2.1          # via -r requirements/base.in, -r requirements/test.txt
-django==2.2.13            # via -r requirements/base.in, -r requirements/test.txt, django-pyfs
+distlib==0.3.1            # via -r requirements/test.txt, virtualenv
+django-pyfs==2.2          # via -r requirements/base.in, -r requirements/test.txt
+django==2.2.14            # via -r requirements/base.in, -r requirements/test.txt, django-pyfs
 docutils==0.15.2          # via -r requirements/test.txt, botocore
-edx-lint==1.4.1           # via -r requirements/quality.in
+edx-lint==1.5.0           # via -r requirements/quality.in
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 fs-s3fs==1.1.1            # via -r requirements/base.in, -r requirements/test.txt, django-pyfs
 fs==2.4.11                # via -r requirements/test.txt, django-pyfs, fs-s3fs, xblock
-idna==2.9                 # via -r requirements/test.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
+idna==2.10                # via -r requirements/test.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-time==0.2.0        # via -r requirements/test.txt, cookiecutter
 jinja2==2.11.2            # via -r requirements/test.txt, cookiecutter, jinja2-time
 jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
 lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via -r requirements/base.in, -r requirements/test.txt, acid-xblock, bok-choy
-lxml==4.5.1               # via -r requirements/base.in, -r requirements/test.txt, xblock
+lxml==4.5.2               # via -r requirements/base.in, -r requirements/test.txt, xblock
 mako==1.1.3               # via -r requirements/test.txt, acid-xblock
 markupsafe==1.1.1         # via -r requirements/test.txt, cookiecutter, jinja2, mako, xblock
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.in, -r requirements/test.txt
-more-itertools==8.3.0     # via -r requirements/test.txt, pytest
+more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 needle==0.5.0             # via -r requirements/test.txt, bok-choy
 nose==1.3.7               # via -r requirements/test.txt, needle
 packaging==20.4           # via -r requirements/test.txt, pytest, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pillow==7.1.2             # via -r requirements/test.txt, needle
+pillow==7.2.0             # via -r requirements/test.txt, needle
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 poyo==0.5.0               # via -r requirements/test.txt, cookiecutter
-py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pypng==0.0.20             # via -r requirements/base.in, -r requirements/test.txt
-pytest-cov==2.9.0         # via -r requirements/test.in, -r requirements/test.txt
+pytest-cov==2.10.0        # via -r requirements/test.in, -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.in, -r requirements/test.txt
 pytest-rerunfailures==9.0  # via -r requirements/test.in, -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django, pytest-rerunfailures
 python-dateutil==2.8.1    # via -r requirements/test.txt, arrow, botocore, xblock
-python-slugify==4.0.0     # via -r requirements/test.txt, cookiecutter
+python-slugify==4.0.1     # via -r requirements/test.txt, cookiecutter
 pytz==2020.1              # via -r requirements/test.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/test.txt, xblock
-requests==2.23.0          # via -r requirements/base.in, -r requirements/test.txt, cookiecutter
+requests==2.24.0          # via -r requirements/base.in, -r requirements/test.txt, cookiecutter
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 selenium==3.4.1           # via -r requirements/test.in, -r requirements/test.txt, bok-choy, needle
-simplejson==3.17.0        # via -r requirements/base.in, -r requirements/test.txt
-six==1.15.0               # via -r requirements/quality.in, -r requirements/test.txt, astroid, bok-choy, cookiecutter, django-pyfs, edx-lint, fs, fs-s3fs, mock, packaging, pathlib2, python-dateutil, tox, virtualenv, xblock
+simplejson==3.17.2        # via -r requirements/base.in, -r requirements/test.txt
+six==1.15.0               # via -r requirements/test.txt, astroid, bok-choy, cookiecutter, edx-lint, fs, fs-s3fs, mock, packaging, pathlib2, python-dateutil, tox, virtualenv, xblock
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 toml==0.10.1              # via -r requirements/test.txt, tox
 tox-battery==0.6.1        # via -r requirements/test.in, -r requirements/test.txt
-tox==3.15.1               # via -r requirements/test.in, -r requirements/test.txt, tox-battery
+tox==3.17.1               # via -r requirements/test.in, -r requirements/test.txt, tox-battery
 typed-ast==1.4.1          # via astroid
-typing==3.7.4.1           # via -r requirements/test.txt, fs
-urllib3==1.25.9           # via -r requirements/test.txt, botocore, requests
-virtualenv==20.0.21       # via -r requirements/test.txt, tox
-wcwidth==0.2.3            # via -r requirements/test.txt, pytest
+typing==3.7.4.3           # via -r requirements/test.txt, fs
+urllib3==1.25.10          # via -r requirements/test.txt, botocore, requests
+virtualenv==20.0.27       # via -r requirements/test.txt, tox
+wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 web-fragments==0.3.2      # via -r requirements/base.in, -r requirements/test.txt, xblock
 webob==1.8.6              # via -r requirements/base.in, -r requirements/test.txt, xblock
 wrapt==1.11.2             # via astroid

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -7,4 +7,3 @@ edx-lint                  # edX pylint rules and plugins
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
-six                       # Prevents a version conflict between this file and test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,84 +6,84 @@
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock  # via -r requirements/test.txt
 appdirs==1.4.4            # via -r requirements/test.txt, fs, virtualenv
-arrow==0.15.6             # via -r requirements/test.txt, jinja2-time
+arrow==0.15.7             # via -r requirements/test.txt, jinja2-time
 astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 binaryornot==0.4.4        # via -r requirements/test.txt, cookiecutter
 bok_choy==0.7.1           # via -r requirements/test.txt
-boto3==1.13.23            # via -r requirements/test.txt, fs-s3fs
+boto3==1.14.26            # via -r requirements/test.txt, fs-s3fs
 boto==2.49.0              # via -r requirements/test.txt
-botocore==1.16.23         # via -r requirements/test.txt, boto3, s3transfer
-certifi==2020.4.5.1       # via -r requirements/test.txt, requests
+botocore==1.17.26         # via -r requirements/test.txt, boto3, s3transfer
+certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, binaryornot, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, cookiecutter, edx-lint
 cookiecutter==1.7.2       # via -r requirements/test.txt
-coverage==5.1             # via -r requirements/test.txt, pytest-cov
+coverage==5.2             # via -r requirements/test.txt, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
-distlib==0.3.0            # via -r requirements/test.txt, virtualenv
-django-pyfs==2.1          # via -r requirements/test.txt
-django==2.2.13            # via -r requirements/test.txt, django-pyfs
+distlib==0.3.1            # via -r requirements/test.txt, virtualenv
+django-pyfs==2.2          # via -r requirements/test.txt
+django==2.2.14            # via -r requirements/test.txt, django-pyfs
 docutils==0.15.2          # via -r requirements/test.txt, botocore
-edx-lint==1.4.1           # via -r requirements/quality.in
+edx-lint==1.5.0           # via -r requirements/quality.in
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 fs-s3fs==1.1.1            # via -r requirements/test.txt, django-pyfs
 fs==2.4.11                # via -r requirements/test.txt, django-pyfs, fs-s3fs, xblock
-idna==2.9                 # via -r requirements/test.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
+idna==2.10                # via -r requirements/test.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-time==0.2.0        # via -r requirements/test.txt, cookiecutter
 jinja2==2.11.2            # via -r requirements/test.txt, cookiecutter, jinja2-time
 jmespath==0.10.0          # via -r requirements/test.txt, boto3, botocore
 lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via -r requirements/test.txt, acid-xblock, bok-choy
-lxml==4.5.1               # via -r requirements/test.txt, xblock
+lxml==4.5.2               # via -r requirements/test.txt, xblock
 mako==1.1.3               # via -r requirements/test.txt, acid-xblock
 markupsafe==1.1.1         # via -r requirements/test.txt, cookiecutter, jinja2, mako, xblock
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/test.txt
-more-itertools==8.3.0     # via -r requirements/test.txt, pytest
+more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 needle==0.5.0             # via -r requirements/test.txt, bok-choy
 nose==1.3.7               # via -r requirements/test.txt, needle
 packaging==20.4           # via -r requirements/test.txt, pytest, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pillow==7.1.2             # via -r requirements/test.txt, needle
+pillow==7.2.0             # via -r requirements/test.txt, needle
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 poyo==0.5.0               # via -r requirements/test.txt, cookiecutter
-py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pypng==0.0.20             # via -r requirements/test.txt
-pytest-cov==2.9.0         # via -r requirements/test.txt
+pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest-rerunfailures==9.0  # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django, pytest-rerunfailures
 python-dateutil==2.8.1    # via -r requirements/test.txt, arrow, botocore, xblock
-python-slugify==4.0.0     # via -r requirements/test.txt, cookiecutter
+python-slugify==4.0.1     # via -r requirements/test.txt, cookiecutter
 pytz==2020.1              # via -r requirements/test.txt, django, fs, xblock
 pyyaml==5.3.1             # via -r requirements/test.txt, xblock
-requests==2.23.0          # via -r requirements/test.txt, cookiecutter
+requests==2.24.0          # via -r requirements/test.txt, cookiecutter
 s3transfer==0.3.3         # via -r requirements/test.txt, boto3
 selenium==3.4.1           # via -r requirements/test.txt, bok-choy, needle
-simplejson==3.17.0        # via -r requirements/test.txt
-six==1.15.0               # via -r requirements/quality.in, -r requirements/test.txt, astroid, bok-choy, cookiecutter, django-pyfs, edx-lint, fs, fs-s3fs, mock, packaging, pathlib2, python-dateutil, tox, virtualenv, xblock
+simplejson==3.17.2        # via -r requirements/test.txt
+six==1.15.0               # via -r requirements/test.txt, astroid, bok-choy, cookiecutter, edx-lint, fs, fs-s3fs, mock, packaging, pathlib2, python-dateutil, tox, virtualenv, xblock
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 text-unidecode==1.3       # via -r requirements/test.txt, python-slugify
 toml==0.10.1              # via -r requirements/test.txt, tox
 tox-battery==0.6.1        # via -r requirements/test.txt
-tox==3.15.1               # via -r requirements/test.txt, tox-battery
+tox==3.17.1               # via -r requirements/test.txt, tox-battery
 typed-ast==1.4.1          # via astroid
-typing==3.7.4.1           # via -r requirements/test.txt, fs
-urllib3==1.25.9           # via -r requirements/test.txt, botocore, requests
-virtualenv==20.0.21       # via -r requirements/test.txt, tox
-wcwidth==0.2.3            # via -r requirements/test.txt, pytest
+typing==3.7.4.3           # via -r requirements/test.txt, fs
+urllib3==1.25.10          # via -r requirements/test.txt, botocore, requests
+virtualenv==20.0.27       # via -r requirements/test.txt, tox
+wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 web-fragments==0.3.2      # via -r requirements/test.txt, xblock
 webob==1.8.6              # via -r requirements/test.txt, xblock
 wrapt==1.11.2             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,69 +6,69 @@
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock  # via -r requirements/test.in
 appdirs==1.4.4            # via fs, virtualenv
-arrow==0.15.6             # via jinja2-time
+arrow==0.15.7             # via jinja2-time
 attrs==19.3.0             # via pytest
 binaryornot==0.4.4        # via cookiecutter
 bok_choy==0.7.1           # via -r requirements/test.in
-boto3==1.13.23            # via fs-s3fs
+boto3==1.14.26            # via fs-s3fs
 boto==2.49.0              # via -r requirements/base.in
-botocore==1.16.23         # via boto3, s3transfer
-certifi==2020.4.5.1       # via requests
+botocore==1.17.26         # via boto3, s3transfer
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via binaryornot, requests
 click==7.1.2              # via cookiecutter
 cookiecutter==1.7.2       # via -r requirements/base.in
-coverage==5.1             # via -r requirements/test.in, pytest-cov
+coverage==5.2             # via -r requirements/test.in, pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
-distlib==0.3.0            # via virtualenv
-django-pyfs==2.1          # via -r requirements/base.in
+distlib==0.3.1            # via virtualenv
+django-pyfs==2.2          # via -r requirements/base.in
 docutils==0.15.2          # via botocore
 filelock==3.0.12          # via tox, virtualenv
 fs-s3fs==1.1.1            # via -r requirements/base.in, django-pyfs
 fs==2.4.11                # via django-pyfs, fs-s3fs, xblock
-idna==2.9                 # via requests
-importlib-metadata==1.6.1  # via importlib-resources, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 jinja2-time==0.2.0        # via cookiecutter
 jinja2==2.11.2            # via cookiecutter, jinja2-time
 jmespath==0.10.0          # via boto3, botocore
 lazy==1.4                 # via -r requirements/base.in, acid-xblock, bok-choy
-lxml==4.5.1               # via -r requirements/base.in, xblock
+lxml==4.5.2               # via -r requirements/base.in, xblock
 mako==1.1.3               # via acid-xblock
 markupsafe==1.1.1         # via cookiecutter, jinja2, mako, xblock
 mock==3.0.5               # via -r requirements/test.in
-more-itertools==8.3.0     # via pytest
+more-itertools==8.4.0     # via pytest
 needle==0.5.0             # via bok-choy
 nose==1.3.7               # via needle
 packaging==20.4           # via pytest, tox
 pathlib2==2.3.5           # via pytest
-pillow==7.1.2             # via needle
+pillow==7.2.0             # via needle
 pluggy==0.13.1            # via pytest, tox
 poyo==0.5.0               # via cookiecutter
-py==1.8.1                 # via pytest, tox
+py==1.9.0                 # via pytest, tox
 pyparsing==2.4.7          # via packaging
 pypng==0.0.20             # via -r requirements/base.in
-pytest-cov==2.9.0         # via -r requirements/test.in
+pytest-cov==2.10.0        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest-rerunfailures==9.0  # via -r requirements/test.in
 pytest==5.4.3             # via pytest-cov, pytest-django, pytest-rerunfailures
 python-dateutil==2.8.1    # via arrow, botocore, xblock
-python-slugify==4.0.0     # via cookiecutter
+python-slugify==4.0.1     # via cookiecutter
 pytz==2020.1              # via django, fs, xblock
 pyyaml==5.3.1             # via xblock
-requests==2.23.0          # via -r requirements/base.in, cookiecutter
+requests==2.24.0          # via -r requirements/base.in, cookiecutter
 s3transfer==0.3.3         # via boto3
 selenium==3.4.1           # via -r requirements/test.in, bok-choy, needle
-simplejson==3.17.0        # via -r requirements/base.in
-six==1.15.0               # via bok-choy, cookiecutter, django-pyfs, fs, fs-s3fs, mock, packaging, pathlib2, python-dateutil, tox, virtualenv, xblock
+simplejson==3.17.2        # via -r requirements/base.in
+six==1.15.0               # via bok-choy, cookiecutter, fs, fs-s3fs, mock, packaging, pathlib2, python-dateutil, tox, virtualenv, xblock
 sqlparse==0.3.1           # via django
 text-unidecode==1.3       # via python-slugify
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/test.in
-tox==3.15.1               # via -r requirements/test.in, tox-battery
-typing==3.7.4.1           # via fs
-urllib3==1.25.9           # via botocore, requests
-virtualenv==20.0.21       # via tox
-wcwidth==0.2.3            # via pytest
+tox==3.17.1               # via -r requirements/test.in, tox-battery
+typing==3.7.4.3           # via fs
+urllib3==1.25.10          # via botocore, requests
+virtualenv==20.0.27       # via tox
+wcwidth==0.2.5            # via pytest
 web-fragments==0.3.2      # via -r requirements/base.in, xblock
 webob==1.8.6              # via -r requirements/base.in, xblock
 xblock==1.3.1             # via -r requirements/base.in, acid-xblock

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,24 +5,24 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
-certifi==2020.4.5.1       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.4            # via -r requirements/travis.in
-coverage==5.1             # via codecov
-distlib==0.3.0            # via virtualenv
+codecov==2.1.8            # via -r requirements/travis.in
+coverage==5.2             # via codecov
+distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-idna==2.9                 # via requests
-importlib-metadata==1.6.1  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.1                 # via tox
+py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.23.0          # via codecov
+requests==2.24.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.15.1               # via -r requirements/travis.in, tox-battery
-urllib3==1.25.9           # via requests
-virtualenv==20.0.21       # via tox
+tox==3.17.1               # via -r requirements/travis.in, tox-battery
+urllib3==1.25.10          # via requests
+virtualenv==20.0.27       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/sample_xblocks/basic/content.py
+++ b/sample_xblocks/basic/content.py
@@ -6,7 +6,6 @@
 from string import Template
 
 from lxml import etree
-from six import text_type
 from web_fragments.fragment import Fragment
 from xblock.core import Scope, String, XBlock
 
@@ -172,7 +171,7 @@ class HtmlBlock(XBlock):
         """
         block = runtime.construct_xblock_from_class(cls, keys)
 
-        block.content = text_type(node.text or u"")
+        block.content = str(node.text or u"")
         for child in node:
             block.content += etree.tostring(child, encoding='unicode')
 

--- a/sample_xblocks/basic/test/test_view_counter.py
+++ b/sample_xblocks/basic/test/test_view_counter.py
@@ -3,7 +3,6 @@
 
 
 from mock import Mock
-from six.moves import range
 from xblock.runtime import DictKeyValueStore, KvsFieldData
 from xblock.test.tools import TestRuntime as Runtime  # Workaround for pytest trying to collect "TestRuntime" as a test
 

--- a/sample_xblocks/filethumbs/filethumbs.py
+++ b/sample_xblocks/filethumbs/filethumbs.py
@@ -24,8 +24,6 @@ import logging
 
 import pkg_resources
 import png
-from six import text_type
-from six.moves import map
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Boolean, Scope
@@ -76,7 +74,7 @@ class FileThumbsBlock(XBlock):
         # Load the HTML fragment from within the package and fill in the template
         html_str = pkg_resources.resource_string(__name__,
                                                  "static/html/thumbs.html").decode('utf-8')
-        frag = Fragment(text_type(html_str))
+        frag = Fragment(str(html_str))
 
         if not self.fs.exists(u"thumbsvotes.json"):
             with self.fs.open(u'thumbsvotes.json', 'wb') as file_output:
@@ -90,11 +88,11 @@ class FileThumbsBlock(XBlock):
         # Load the CSS and JavaScript fragments from within the package
         css_str = pkg_resources.resource_string(__name__,
                                                 "static/css/thumbs.css").decode('utf-8')
-        frag.add_css(text_type(css_str))
+        frag.add_css(str(css_str))
 
         js_str = pkg_resources.resource_string(__name__,
                                                "static/js/src/thumbs.js").decode('utf-8')
-        frag.add_javascript(text_type(js_str))
+        frag.add_javascript(str(js_str))
 
         with self.fs.open(u'uparrow.png', 'wb') as file_output:
             png.Writer(len(ARROW[0]), len(ARROW), greyscale=True, bitdepth=1).write(file_output, ARROW)

--- a/sample_xblocks/thumbs/thumbs.py
+++ b/sample_xblocks/thumbs/thumbs.py
@@ -5,7 +5,6 @@
 import logging
 
 import pkg_resources
-from six import text_type
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock, XBlockAside
 from xblock.fields import Boolean, Integer, Scope
@@ -39,16 +38,16 @@ class ThumbsBlockBase:
         # Load the HTML fragment from within the package and fill in the template
         html_str = pkg_resources.resource_string(__name__,
                                                  "static/html/thumbs.html").decode('utf-8')
-        frag = Fragment(text_type(html_str).format(block=self))
+        frag = Fragment(str(html_str).format(block=self))
 
         # Load the CSS and JavaScript fragments from within the package
         css_str = pkg_resources.resource_string(__name__,
                                                 "static/css/thumbs.css").decode('utf-8')
-        frag.add_css(text_type(css_str))
+        frag.add_css(str(css_str))
 
         js_str = pkg_resources.resource_string(__name__,
                                                "static/js/src/thumbs.js").decode('utf-8')
-        frag.add_javascript(text_type(js_str))
+        frag.add_javascript(str(js_str))
 
         frag.initialize_js('ThumbsBlock')
         return frag

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ package_data.update(find_package_data("workbench", ["static", "templates", "test
 
 setup(
     name='xblock-sdk',
-    version='0.2.1',
+    version='0.2.2',
     description='XBlock SDK',
     packages=[
         'sample_xblocks',

--- a/workbench/runtime.py
+++ b/workbench/runtime.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 
 from mock import Mock
-from six import iteritems
 from web_fragments.fragment import Fragment
 from xblock.core import XBlockAside
 from xblock.exceptions import NoSuchDefinition, NoSuchUsage
@@ -258,7 +257,7 @@ class WorkbenchRuntime(Runtime):
         # This is useful for instances of workbench used to develop
         # XBlocks that require services that may be too specific
         # to include in the default workbench configuration.
-        for service_name, service_path in iteritems(settings.WORKBENCH.get('services', {})):
+        for service_name, service_path in (settings.WORKBENCH.get('services', {})).items():
             service = self._load_service(service_path)
             if service is not None:
                 services[service_name] = service

--- a/workbench/scenarios.py
+++ b/workbench/scenarios.py
@@ -13,6 +13,8 @@ from xblock.core import XBlock
 from django.conf import settings
 from django.template.defaultfilters import slugify
 
+from .runtime import WORKBENCH_KVS, WorkbenchRuntime
+
 log = logging.getLogger(__name__)
 
 # Build the scenarios, which are named trees of usages.
@@ -26,7 +28,6 @@ def add_xml_scenario(scname, description, xml):
     """
     Add a scenario defined in XML.
     """
-    from .runtime import WorkbenchRuntime
     assert scname not in SCENARIOS, u"Already have a %r scenario" % scname
     runtime = WorkbenchRuntime()
 
@@ -69,7 +70,6 @@ def init_scenarios():
     """
     # Clear any existing scenarios, since this is used repeatedly during testing.
     SCENARIOS.clear()
-    from .runtime import WORKBENCH_KVS
     if settings.WORKBENCH['reset_state_on_restart']:
         WORKBENCH_KVS.clear()
     else:

--- a/workbench/test/test_problems.py
+++ b/workbench/test/test_problems.py
@@ -6,7 +6,6 @@ import unittest
 
 from bok_choy.query import BrowserQuery
 from selenium.common.exceptions import StaleElementReferenceException
-from six.moves import range
 
 from workbench import scenarios
 from workbench.test.selenium_test import SeleniumTest

--- a/workbench/test/test_views.py
+++ b/workbench/test/test_views.py
@@ -5,8 +5,6 @@ import functools
 import json
 
 import pytest
-from six import text_type
-from six.moves import zip
 from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.core import Scope, String, XBlock
@@ -202,7 +200,7 @@ class XBlockWithHandlers(XBlock):
             'a': request.GET.get('a', "no-a"),
             'b': request.GET.get('b', "no-b"),
         })
-        return Response(text=text_type(response_json), content_type='application/json')
+        return Response(text=str(response_json), content_type='application/json')
 
     @XBlock.handler
     def send_it_back_public(self, request, suffix=''):
@@ -213,7 +211,7 @@ class XBlockWithHandlers(XBlock):
             'a': request.GET.get('a', "no-a"),
             'b': request.GET.get('b', "no-b"),
         })
-        return Response(text=text_type(response_json), content_type='application/json')
+        return Response(text=str(response_json), content_type='application/json')
 
 
 @temp_scenario(XBlockWithHandlers, 'with-handlers')


### PR DESCRIPTION
**Issue:** [BOM-1951](https://openedx.atlassian.net/browse/BOM-1951)

### Description
- package `six` is no longer required after updating to python3, hence removed all usages of it.