### PR TITLE
Include tests in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,11 @@ package_data = {}  # pylint: disable=invalid-name
 package_data.update(find_package_data("sample_xblocks.basic", ["public", "templates"]))
 package_data.update(find_package_data("sample_xblocks.thumbs", ["static"]))
 package_data.update(find_package_data("sample_xblocks.filethumbs", ["static"]))
-package_data.update(find_package_data("workbench", ["static", "templates"]))
+package_data.update(find_package_data("workbench", ["static", "templates", "test"]))
 
 setup(
     name='xblock-sdk',
-    version='0.2.0',
+    version='0.2.1',
     description='XBlock SDK',
     packages=[
         'sample_xblocks',


### PR DESCRIPTION
- We need the test folder of this package in `xblock-utils`. When we install it from PyPI in `xblock-utils` there are import errors due to this folder not being there.
Reference : https://github.com/edx/xblock-utils/pull/88