### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,7 +197,7 @@ You can discuss this code on the `edx-code Google Group`__ or in the
 
 __ https://groups.google.com/group/edx-code
 
-.. |build-status| image:: https://travis-ci.org/edx/xblock-sdk.svg?branch=master
-   :target: https://travis-ci.org/edx/xblock-sdk
+.. |build-status| image:: https://travis-ci.com/edx/xblock-sdk.svg?branch=master
+   :target: https://travis-ci.com/edx/xblock-sdk
 .. |coverage-status| image:: https://coveralls.io/repos/edx/xblock-sdk/badge.png
    :target: https://coveralls.io/r/edx/xblock-sdk


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089