### PR TITLE
Update base add docker compose yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,30 @@
-FROM edxops/xenial-common:latest
+FROM edxops/focal-common:latest
 RUN apt-get update && apt-get install -y \
     gettext \
     lib32z1-dev \
     libjpeg62-dev \
-    libxslt-dev \
-    libz-dev \
-    python3.5 \
+    libxslt1-dev \
+    zlib1g-dev \
+    python3 \
     python3-dev \
     python3-pip && \
     pip3 install --upgrade pip setuptools && \
     rm -rf /var/lib/apt/lists/*
 
-
 COPY . /usr/local/src/xblock-sdk
 WORKDIR /usr/local/src/xblock-sdk
 
-RUN pip install -r /usr/local/src/xblock-sdk/requirements/dev.txt 
+RUN ln -s /usr/bin/python3.8 /usr/bin/python && \
+    /usr/bin/python3 -m pip install --upgrade pip && \
+    pip install -r /usr/local/src/xblock-sdk/requirements/dev.txt
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x -o /tmp/nodejs-setup
-RUN /bin/bash /tmp/nodejs-setup
-RUN rm /tmp/nodejs-setup
-RUN apt-get -y install nodejs
-RUN echo $PYTHONPATH
+RUN curl -sL https://deb.nodesource.com/setup_14.x -o /tmp/nodejs-setup && \
+    /bin/bash /tmp/nodejs-setup && \
+    rm /tmp/nodejs-setup && \
+    apt-get -y install nodejs && \
+    echo $PYTHONPATH && \
+    make install
 
-RUN make install
 EXPOSE 8000
 ENTRYPOINT ["python3", "manage.py"]
 CMD ["runserver", "0.0.0.0:8000"]

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,23 @@ selfcheck: ## check that the Makefile is well-formed
 	@echo "The Makefile is well-formed."
 
 docker_build:
-	docker build . -t "openedx/xblock-sdk:latest"
+	docker-compose build
+
+# devstack-themed shortcuts
+dev.up: # Starts all containers
+	docker-compose up -d
+
+dev.up.build:
+	docker-compose up -d --build
+
+dev.down: # Kills containers and all of their data that isn't in volumes
+	docker-compose down
+
+dev.stop: # Stops containers so they can be restarted
+	docker-compose stop
+
+app-shell: # Run bash in the container as root
+	docker exec -u 0 -it edx.devstack.xblock-sdk bash
 
 travis_docker_auth:
 	echo "$$DOCKER_PASSWORD" | docker login -u "$$DOCKER_USERNAME" --password-stdin

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,8 @@ This code runs on Python 3.5 or newer.
 
     $ sudo apt-get install python-dev libxml2-dev libxslt-dev lib32z1-dev libjpeg62-dev
 
+    Note: Debian 10 needs libjpeg62-turbo-dev instead of libjpeg62-dev.
+
 #.  Get a local copy of this repo.
 
 #.  Create and activate a virtualenv to work in.
@@ -37,20 +39,64 @@ This code runs on Python 3.5 or newer.
 Docker
 ------
 
-Alternatively, you can build and run the xblock-sdk in Docker.
+Alternatively, you can build and run the xblock-sdk in Docker (we are using docker-compose which
+can be installed as explained at https://docs.docker.com/compose/install/)
 
 After cloning this repository locally, go into the repository directory and build the Docker image::
 
-    $ docker build -t xblock-sdk .
+    $ make docker_build
+
+or manually run
+
+    $ docker-compose build
 
 You can then run the locally-built version using the following command::
 
-    $ docker run -d -p 8000:8000 --name xblock-sdk xblock-sdk
+    $ make dev.up
+
+or manually run::
+
+    $ docker-compose up -d
+
+and stop the container (without removing data) by::
+
+    $ make dev.stop
+
+or manually run::
+
+    $ docker-compose stop
+
+Note, using::
+
+    $ make dev.down
+
+or::
+
+    $ docker-compose down
+
+will shut down the container and delete non-persistant data.
+
+On the first startup run the following command to create the SQLite database.
+(Otherwise you will get an error no such table: workbench_xblockstate.)
+
+Command::
+
+    $ docker container exec -it edx.devstack.xblock-sdk python3.8 manage.py migrate
 
 You should now be able to access the XBlock SDK environment in your browser at http://localhost:8000
 
+You can open a bash shell in the running container by using::
+
+    $ make app-shell
+
+or::
+
+    $ docker container exec -it edx.devstack.xblock-sdk bash
+
 Testing
 --------
+
+If using Docker, all these commands need to be run inside the xblock-sdk container.
 
 Testing is done via tox to test all supported versions:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.5'
+services:
+  xblock_sdk:
+    image: xblock-sdk
+    container_name: edx.devstack.xblock-sdk
+
+    build: .
+
+    volumes:
+      # Provide a persistant location for the SQLite database
+      - xblock-var:/usr/local/src/xblock-sdk/var
+
+    hostname: localhost
+    ports:
+      - "8000:8000"
+
+# Persistant storage volumes:
+volumes:
+  # For the SQLite database
+  xblock-var:

--- a/manage.py
+++ b/manage.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Manage.py file for XBlock"""
 import os
 import sys


### PR DESCRIPTION
The `docker-compose.yml` will make startup/shutdown easier for Docker users.
It also provides persistent storage for the SQLite database and an easy approach to using "bind" mounts.
Dockerfile was updated to use Ubuntu focal (20.04 LTS) instead of Xenial (16.04 LTS) and to use Node.js v14 instead of the obsolete v12.